### PR TITLE
Ignore insufficient funds errors on tracing

### DIFF
--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -990,6 +990,9 @@ func (api *API) traceTx(ctx context.Context, tx *types.Transaction, message *cor
 	statedb.SetTxContext(txctx.TxHash, txctx.TxIndex)
 	_, err = core.ApplyTransactionWithEVM(message, api.backend.ChainConfig(), new(core.GasPool).AddGas(message.GasLimit), statedb, vmctx.BlockNumber, txctx.BlockHash, tx, &usedGas, vmenv)
 	if err != nil {
+		if err == core.ErrInsufficientFunds {
+			return []byte("{}"), nil
+		}
 		return nil, fmt.Errorf("tracing failed: %w", err)
 	}
 	return tracer.GetResult()

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -990,6 +990,7 @@ func (api *API) traceTx(ctx context.Context, tx *types.Transaction, message *cor
 	statedb.SetTxContext(txctx.TxHash, txctx.TxIndex)
 	_, err = core.ApplyTransactionWithEVM(message, api.backend.ChainConfig(), new(core.GasPool).AddGas(message.GasLimit), statedb, vmctx.BlockNumber, txctx.BlockHash, tx, &usedGas, vmenv)
 	if err != nil {
+		// Due to how our mempool works, a transaction with insufficient funds can be included in a block. For tracing purposes, we should ignore this.
 		if err == core.ErrInsufficientFunds {
 			return []byte("{}"), nil
 		}

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -25,6 +25,7 @@ import (
 	"math/big"
 	"os"
 	"runtime"
+	"strings"
 	"sync"
 	"time"
 
@@ -991,8 +992,8 @@ func (api *API) traceTx(ctx context.Context, tx *types.Transaction, message *cor
 	_, err = core.ApplyTransactionWithEVM(message, api.backend.ChainConfig(), new(core.GasPool).AddGas(message.GasLimit), statedb, vmctx.BlockNumber, txctx.BlockHash, tx, &usedGas, vmenv)
 	if err != nil {
 		// Due to how our mempool works, a transaction with insufficient funds can be included in a block. For tracing purposes, we should ignore this.
-		if err == core.ErrInsufficientFunds {
-			return []byte("{}"), nil
+		if strings.Contains(err.Error(), core.ErrInsufficientFunds.Error()) {
+			return json.RawMessage(`{}`), nil
 		}
 		return nil, fmt.Errorf("tracing failed: %w", err)
 	}


### PR DESCRIPTION
We've recently been getting a few txs that have entered our blocks and error-ing out on tracing with [insufficient funds](https://github.com/sei-protocol/go-ethereum/blob/7d8ba55b6247c9906602533434e19e678894f1f8/core/state_transition.go#L259) which shouldn't normally happen but is sometimes possible due to the way our mempool works. Because no state is touched/changed, we have decided to just ignore these errors in tracing and return an empty trace. This should allow full block tracing to work for subsequent txs in the block.