### PR TITLE
Catch panics on cosmos out of gas in estimateGas

### DIFF
--- a/eth/gasestimator/gasestimator.go
+++ b/eth/gasestimator/gasestimator.go
@@ -184,9 +184,16 @@ func Estimate(ctx context.Context, call *core.Message, opts *Options, gasCap uin
 // returns true if the transaction fails for a reason that might be related to
 // not enough gas. A non-nil error means execution failed due to reasons unrelated
 // to the gas limit.
-func execute(ctx context.Context, call *core.Message, opts *Options, gasLimit uint64) (bool, *core.ExecutionResult, error) {
+func execute(ctx context.Context, call *core.Message, opts *Options, gasLimit uint64) (failed bool, execResult *core.ExecutionResult, err error) {
 	// Configure the call for this specific execution (and revert the change after)
 	defer func(gas uint64) { call.GasLimit = gas }(call.GasLimit)
+	defer func() {
+		if r := recover(); r != nil {
+			failed = true
+			execResult = nil
+			err = nil
+		}
+	}()
 	call.GasLimit = gasLimit
 
 	// Execute the call and separate execution faults caused by a lack of gas or


### PR DESCRIPTION
Cosmos sdk gas meter panics when out it hits out of gas. However, Ethereum's estimateGas will intentionally try to "find" the limit and at times run out of gas when simulating (see https://github.com/sei-protocol/go-ethereum/blob/master/eth/gasestimator/gasestimator.go#L131-L148). Therefore, we need to catch this panic and let estimateGas continue it's binary search