### PR TITLE
add back base fee true in tracer

### DIFF
--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -1035,7 +1035,7 @@ func (api *API) traceTx(ctx context.Context, tx *types.Transaction, message *cor
 		}
 	}
 	txCtx := core.NewEVMTxContext(message)
-	vmenv := vm.NewEVM(vmctx, txCtx, statedb, api.backend.ChainConfig(), vm.Config{Tracer: tracer.Hooks}, api.backend.GetCustomPrecompiles(vmctx.BlockNumber.Int64()))
+	vmenv := vm.NewEVM(vmctx, txCtx, statedb, api.backend.ChainConfig(), vm.Config{Tracer: tracer.Hooks, NoBaseFee: true}, api.backend.GetCustomPrecompiles(vmctx.BlockNumber.Int64()))
 	statedb.SetLogger(tracer.Hooks)
 
 	// Define a meaningful timeout of a single transaction trace


### PR DESCRIPTION
Enables `NoBaseFee: true` in the vm config used for tracing. In `StatelessChecks`, there's a check for gas params. If the user doesn't specify GasFeeCap or GasTipCap, having `NoBaseFee: true` allows this check to be skipped over:
```
// Skip the checks if gas fields are zero and baseFee was explicitly disabled (eth_call)
skipCheck := st.evm.Config.NoBaseFee && msg.GasFeeCap.BitLen() == 0 && msg.GasTipCap.BitLen() == 0
```
If the user does want base fee checked against their gas params, they can still do so by specifying max fee and max priority fee params in their simulation / trace call.

pulled in by https://github.com/sei-protocol/sei-chain/pull/2203