### PR TITLE
feat: add AbortError which bubbles up the callstack

### DIFF
--- a/core/vm/errors.go
+++ b/core/vm/errors.go
@@ -44,6 +44,13 @@ var (
 	errStopToken = errors.New("stop token")
 )
 
+// AbortError is an interface that errors can implement to signal that execution
+// should be aborted immediately and the error should propagate through the call stack.
+type AbortError interface {
+	error
+	IsAbortError() bool
+}
+
 // ErrStackUnderflow wraps an evm error when the items on the stack less
 // than the minimal requirement.
 type ErrStackUnderflow struct {

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -256,6 +256,11 @@ func (evm *EVM) Call(caller common.Address, addr common.Address, input []byte, g
 			gas = contract.Gas
 		}
 	}
+	// Check if this is an abort error that should propagate through the call stack
+	if abortErr, ok := err.(AbortError); ok && abortErr.IsAbortError() {
+		return ret, gas, abortErr
+	}
+	
 	// When an error was returned by the EVM or when setting the creation code
 	// above we revert to the snapshot and consume any gas remaining. Additionally,
 	// when we're in homestead this also counts for code storage gas errors.
@@ -314,6 +319,11 @@ func (evm *EVM) CallCode(caller common.Address, addr common.Address, input []byt
 		ret, err = evm.EVMInterpreter.Run(CALLCODE, contract, input, false)
 		gas = contract.Gas
 	}
+	// Check if this is an abort error that should propagate through the call stack
+	if abortErr, ok := err.(AbortError); ok && abortErr.IsAbortError() {
+		return ret, gas, abortErr
+	}
+
 	if err != nil {
 		evm.StateDB.RevertToSnapshot(snapshot)
 		if err != ErrExecutionReverted {
@@ -359,6 +369,10 @@ func (evm *EVM) DelegateCall(originCaller common.Address, caller common.Address,
 		contract.SetCallCode(evm.resolveCodeHash(addr), evm.resolveCode(addr))
 		ret, err = evm.EVMInterpreter.Run(DELEGATECALL, contract, input, false)
 		gas = contract.Gas
+	}
+	// Check if this is an abort error that should propagate through the call stack
+	if abortErr, ok := err.(AbortError); ok && abortErr.IsAbortError() {
+		return ret, gas, abortErr
 	}
 	if err != nil {
 		evm.StateDB.RevertToSnapshot(snapshot)
@@ -414,6 +428,10 @@ func (evm *EVM) StaticCall(caller common.Address, addr common.Address, input []b
 		// when we're in Homestead this also counts for code storage gas errors.
 		ret, err = evm.EVMInterpreter.Run(STATICCALL, contract, input, true)
 		gas = contract.Gas
+	}
+	// Check if this is an abort error that should propagate through the call stack
+	if abortErr, ok := err.(AbortError); ok && abortErr.IsAbortError() {
+		return ret, gas, abortErr
 	}
 	if err != nil {
 		evm.StateDB.RevertToSnapshot(snapshot)

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -756,6 +756,9 @@ func opCall(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byt
 		gas += params.CallStipend
 	}
 	ret, returnGas, err := interpreter.evm.Call(scope.Contract.Address(), toAddr, args, gas, &value)
+	if abortErr, ok := err.(AbortError); ok && abortErr.IsAbortError() {
+		return ret, abortErr
+	}
 
 	if err != nil {
 		temp.Clear()
@@ -790,6 +793,10 @@ func opCallCode(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([
 	}
 
 	ret, returnGas, err := interpreter.evm.CallCode(scope.Contract.Address(), toAddr, args, gas, &value)
+	if abortErr, ok := err.(AbortError); ok && abortErr.IsAbortError() {
+		return ret, abortErr
+	}
+
 	if err != nil {
 		temp.Clear()
 	} else {
@@ -819,6 +826,10 @@ func opDelegateCall(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext
 	args := scope.Memory.GetPtr(inOffset.Uint64(), inSize.Uint64())
 
 	ret, returnGas, err := interpreter.evm.DelegateCall(scope.Contract.Caller(), scope.Contract.Address(), toAddr, args, gas, scope.Contract.value)
+	if abortErr, ok := err.(AbortError); ok && abortErr.IsAbortError() {
+		return ret, abortErr
+	}
+
 	if err != nil {
 		temp.Clear()
 	} else {
@@ -848,6 +859,9 @@ func opStaticCall(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) 
 	args := scope.Memory.GetPtr(inOffset.Uint64(), inSize.Uint64())
 
 	ret, returnGas, err := interpreter.evm.StaticCall(scope.Contract.Address(), toAddr, args, gas)
+	if abortErr, ok := err.(AbortError); ok && abortErr.IsAbortError() {
+		return ret, abortErr
+	}
 	if err != nil {
 		temp.Clear()
 	} else {


### PR DESCRIPTION
This pairs with the work in https://github.com/sei-protocol/sei-chain/pull/2670, which allows us to bubble certain errors all the way up the callstack, so that the executor can exert control-flow logic on them.