### PR TITLE
rpc: add WebSocket concurrent request-byte admission control (PLT-776)

### DIFF
--- a/rpc/client.go
+++ b/rpc/client.go
@@ -133,9 +133,9 @@ func (cc *clientConn) close(err error, inflightReq *requestOp) {
 }
 
 type readOp struct {
-	msgs   []*jsonrpcMessage
-	batch  bool
-	rawLen int64
+	msgs    []*jsonrpcMessage
+	batch   bool
+	release func()
 }
 
 // requestOp represents a pending request. This is used for both batch and non-batch
@@ -642,7 +642,7 @@ func (c *Client) dispatch(codec ServerCodec) {
 	}()
 
 	// Spawn the initial read loop.
-	go c.read(codec)
+	go c.read(conn)
 
 	for {
 		select {
@@ -652,9 +652,9 @@ func (c *Client) dispatch(codec ServerCodec) {
 		// Read path:
 		case op := <-c.readOp:
 			if op.batch {
-				conn.handler.handleBatch(op.msgs, op.rawLen)
+				conn.handler.handleBatch(op.msgs, op.release)
 			} else {
-				conn.handler.handleMsg(op.msgs[0], op.rawLen)
+				conn.handler.handleMsg(op.msgs[0], op.release)
 			}
 
 		case err := <-c.readErr:
@@ -674,9 +674,9 @@ func (c *Client) dispatch(codec ServerCodec) {
 				conn.close(errClientReconnected, lastOp)
 				c.drainRead()
 			}
-			go c.read(newcodec)
-			reading = true
 			conn = c.newClientConn(newcodec)
+			go c.read(conn)
+			reading = true
 			// Re-register the in-flight request on the new handler
 			// because that's where it will be sent.
 			conn.handler.addRequestOp(lastOp)
@@ -708,7 +708,10 @@ func (c *Client) dispatch(codec ServerCodec) {
 func (c *Client) drainRead() {
 	for {
 		select {
-		case <-c.readOp:
+		case op := <-c.readOp:
+			if op.release != nil {
+				op.release()
+			}
 		case <-c.readErr:
 			return
 		}
@@ -716,17 +719,31 @@ func (c *Client) drainRead() {
 }
 
 // read decodes RPC messages from a codec, feeding them into dispatch.
-func (c *Client) read(codec ServerCodec) {
+func (c *Client) read(conn *clientConn) {
+	codec := conn.codec
+	h := conn.handler
 	for {
-		msgs, batch, rawLen, err := codec.readBatch()
-		if _, ok := err.(*json.SyntaxError); ok {
-			msg := errorMessage(&parseError{err.Error()})
-			codec.writeJSON(context.Background(), msg, true)
-		}
-		if err != nil {
+		if err := h.acquirePreDecode(h.rootCtx); err != nil {
 			c.readErr <- err
 			return
 		}
-		c.readOp <- readOp{msgs: msgs, batch: batch, rawLen: rawLen}
+		msgs, batch, rawLen, err := codec.readBatch()
+		if err != nil {
+			h.releasePreDecode()
+			var syntaxErr *json.SyntaxError
+			if errors.As(err, &syntaxErr) {
+				msg := errorMessage(&parseError{err.Error()})
+				codec.writeJSON(context.Background(), msg, true)
+			}
+			c.readErr <- err
+			return
+		}
+		release, err := h.commitFrameBudget(h.rootCtx, rawLen)
+		if err != nil {
+			h.releasePreDecode()
+			c.readErr <- err
+			return
+		}
+		c.readOp <- readOp{msgs: msgs, batch: batch, release: release}
 	}
 }

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/log"
+	"golang.org/x/sync/semaphore"
 )
 
 var (
@@ -89,6 +90,8 @@ type Client struct {
 	// config fields
 	batchItemLimit       int
 	batchResponseMaxSize int
+	wsConcurrentBudget   *semaphore.Weighted
+	readLimit            int64
 
 	// writeConn is used for writing to the connection on the caller's goroutine. It should
 	// only be accessed outside of dispatch, with the write lock held. The write lock is
@@ -120,7 +123,7 @@ func (c *Client) newClientConn(conn ServerCodec) *clientConn {
 	ctx := context.Background()
 	ctx = context.WithValue(ctx, clientContextKey{}, c)
 	ctx = context.WithValue(ctx, peerInfoContextKey{}, conn.peerInfo())
-	handler := newHandler(ctx, conn, c.idgen, c.services, c.batchItemLimit, c.batchResponseMaxSize)
+	handler := newHandler(ctx, conn, c.idgen, c.services, c.batchItemLimit, c.batchResponseMaxSize, c.wsConcurrentBudget, c.readLimit)
 	return &clientConn{conn, handler}
 }
 
@@ -130,8 +133,9 @@ func (cc *clientConn) close(err error, inflightReq *requestOp) {
 }
 
 type readOp struct {
-	msgs  []*jsonrpcMessage
-	batch bool
+	msgs   []*jsonrpcMessage
+	batch  bool
+	rawLen int64
 }
 
 // requestOp represents a pending request. This is used for both batch and non-batch
@@ -248,6 +252,8 @@ func initClient(conn ServerCodec, services *serviceRegistry, cfg *clientConfig) 
 		idgen:                cfg.idgen,
 		batchItemLimit:       cfg.batchItemLimit,
 		batchResponseMaxSize: cfg.batchResponseLimit,
+		wsConcurrentBudget:   cfg.wsConcurrentBudget,
+		readLimit:            cfg.readLimit,
 		writeConn:            conn,
 		close:                make(chan struct{}),
 		closing:              make(chan struct{}),
@@ -646,9 +652,9 @@ func (c *Client) dispatch(codec ServerCodec) {
 		// Read path:
 		case op := <-c.readOp:
 			if op.batch {
-				conn.handler.handleBatch(op.msgs)
+				conn.handler.handleBatch(op.msgs, op.rawLen)
 			} else {
-				conn.handler.handleMsg(op.msgs[0])
+				conn.handler.handleMsg(op.msgs[0], op.rawLen)
 			}
 
 		case err := <-c.readErr:
@@ -712,7 +718,7 @@ func (c *Client) drainRead() {
 // read decodes RPC messages from a codec, feeding them into dispatch.
 func (c *Client) read(codec ServerCodec) {
 	for {
-		msgs, batch, err := codec.readBatch()
+		msgs, batch, rawLen, err := codec.readBatch()
 		if _, ok := err.(*json.SyntaxError); ok {
 			msg := errorMessage(&parseError{err.Error()})
 			codec.writeJSON(context.Background(), msg, true)
@@ -721,6 +727,6 @@ func (c *Client) read(codec ServerCodec) {
 			c.readErr <- err
 			return
 		}
-		c.readOp <- readOp{msgs, batch}
+		c.readOp <- readOp{msgs: msgs, batch: batch, rawLen: rawLen}
 	}
 }

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -741,6 +741,9 @@ func (c *Client) read(conn *clientConn) {
 		release, err := h.commitFrameBudget(h.rootCtx, rawLen)
 		if err != nil {
 			h.releasePreDecode()
+			if resp := frameBudgetExceededResponse(msgs, batch); resp != nil {
+				codec.writeJSON(context.Background(), resp, true)
+			}
 			c.readErr <- err
 			return
 		}

--- a/rpc/client_opt.go
+++ b/rpc/client_opt.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	"github.com/gorilla/websocket"
+	"golang.org/x/sync/semaphore"
 )
 
 // ClientOption is a configuration option for the RPC client.
@@ -41,6 +42,8 @@ type clientConfig struct {
 	idgen              func() ID
 	batchItemLimit     int
 	batchResponseLimit int
+	wsConcurrentBudget *semaphore.Weighted
+	readLimit          int64
 }
 
 func (cfg *clientConfig) initHeaders() {

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -553,14 +553,14 @@ type unsubscribeBlocker struct {
 	quit chan struct{}
 }
 
-func (b *unsubscribeBlocker) readBatch() ([]*jsonrpcMessage, bool, error) {
-	msgs, batch, err := b.ServerCodec.readBatch()
+func (b *unsubscribeBlocker) readBatch() ([]*jsonrpcMessage, bool, int64, error) {
+	msgs, batch, rawLen, err := b.ServerCodec.readBatch()
 	for _, msg := range msgs {
 		if msg.isUnsubscribe() {
 			<-b.quit
 		}
 	}
-	return msgs, batch, err
+	return msgs, batch, rawLen, err
 }
 
 // TestUnsubscribeTimeout verifies that calling the client's Unsubscribe
@@ -618,12 +618,12 @@ type unsubscribeRecorder struct {
 	unsubscribes map[string]bool
 }
 
-func (r *unsubscribeRecorder) readBatch() ([]*jsonrpcMessage, bool, error) {
+func (r *unsubscribeRecorder) readBatch() ([]*jsonrpcMessage, bool, int64, error) {
 	if r.unsubscribes == nil {
 		r.unsubscribes = make(map[string]bool)
 	}
 
-	msgs, batch, err := r.ServerCodec.readBatch()
+	msgs, batch, rawLen, err := r.ServerCodec.readBatch()
 	for _, msg := range msgs {
 		if msg.isUnsubscribe() {
 			var params []string
@@ -633,7 +633,7 @@ func (r *unsubscribeRecorder) readBatch() ([]*jsonrpcMessage, bool, error) {
 			r.unsubscribes[params[0]] = true
 		}
 	}
-	return msgs, batch, err
+	return msgs, batch, rawLen, err
 }
 
 // This checks that Client calls the _unsubscribe method on the server when Unsubscribe is

--- a/rpc/errors.go
+++ b/rpc/errors.go
@@ -61,6 +61,7 @@ const (
 	errcodeDefault          = -32000
 	errcodeTimeout          = -32002
 	errcodeResponseTooLarge = -32003
+	errcodeRequestTooLarge  = -32004
 	errcodePanic            = -32603
 	errcodeMarshalError     = -32603
 
@@ -71,6 +72,7 @@ const (
 	errMsgTimeout          = "request timed out"
 	errMsgResponseTooLarge = "response too large"
 	errMsgBatchTooLarge    = "batch too large"
+	errMsgRequestTooLarge  = "request exceeds concurrent request-byte budget"
 )
 
 type methodNotFoundError struct{ method string }

--- a/rpc/errors.go
+++ b/rpc/errors.go
@@ -61,6 +61,7 @@ const (
 	errcodeDefault          = -32000
 	errcodeTimeout          = -32002
 	errcodeResponseTooLarge = -32003
+	errcodeServerBusy       = -32005
 	errcodePanic            = -32603
 	errcodeMarshalError     = -32603
 
@@ -71,6 +72,7 @@ const (
 	errMsgTimeout          = "request timed out"
 	errMsgResponseTooLarge = "response too large"
 	errMsgBatchTooLarge    = "batch too large"
+	errMsgServerBusy       = "server busy"
 )
 
 type methodNotFoundError struct{ method string }

--- a/rpc/errors.go
+++ b/rpc/errors.go
@@ -61,7 +61,6 @@ const (
 	errcodeDefault          = -32000
 	errcodeTimeout          = -32002
 	errcodeResponseTooLarge = -32003
-	errcodeServerBusy       = -32005
 	errcodePanic            = -32603
 	errcodeMarshalError     = -32603
 
@@ -72,7 +71,6 @@ const (
 	errMsgTimeout          = "request timed out"
 	errMsgResponseTooLarge = "response too large"
 	errMsgBatchTooLarge    = "batch too large"
-	errMsgServerBusy       = "server busy"
 )
 
 type methodNotFoundError struct{ method string }

--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -103,40 +103,66 @@ func newHandler(connCtx context.Context, conn jsonWriter, idgen func() ID, reg *
 	return h
 }
 
-func (h *handler) tryAcquireRequestBytes(rawLen int64) (release func(), ok bool) {
-	if h.wsConcurrentBudget == nil {
-		return func() {}, true
+// wsAdmissionTimeout bounds how long a persistent connection will wait for
+// concurrent-byte budget to free up before a frame is read or committed.
+const wsAdmissionTimeout = 30 * time.Second
+
+// acquirePreDecode reserves frame budget before the codec reads/decodes the next
+// message. The wait is bounded by wsAdmissionTimeout.
+func (h *handler) acquirePreDecode(ctx context.Context) error {
+	if h.wsConcurrentBudget == nil || h.readLimit <= 0 {
+		return nil
 	}
+	ctx, cancel := context.WithTimeout(ctx, wsAdmissionTimeout)
+	defer cancel()
+	if err := h.wsConcurrentBudget.Acquire(ctx, h.readLimit); err != nil {
+		return fmt.Errorf("concurrent request byte budget exhausted: %w", err)
+	}
+	return nil
+}
+
+// releasePreDecode releases a pre-decode reservation after a failed read/decode or a
+// failed commitFrameBudget call.
+func (h *handler) releasePreDecode() {
+	if h.wsConcurrentBudget == nil || h.readLimit <= 0 {
+		return
+	}
+	h.wsConcurrentBudget.Release(h.readLimit)
+}
+
+// commitFrameBudget finalizes the reservation for a successfully decoded frame,
+// reconciling any pre-decode reservation against the frame's actual size.
+func (h *handler) commitFrameBudget(ctx context.Context, rawLen int64) (release func(), err error) {
+	if h.wsConcurrentBudget == nil {
+		return func() {}, nil
+	}
+	if h.readLimit <= 0 {
+		if rawLen <= 0 {
+			return func() {}, nil
+		}
+		ctx, cancel := context.WithTimeout(ctx, wsAdmissionTimeout)
+		defer cancel()
+		if err := h.wsConcurrentBudget.Acquire(ctx, rawLen); err != nil {
+			return nil, fmt.Errorf("concurrent request byte budget exhausted: %w", err)
+		}
+		return func() { h.wsConcurrentBudget.Release(rawLen) }, nil
+	}
+
 	weight := rawLen
 	if weight <= 0 {
 		weight = h.readLimit
 	}
-	if !h.wsConcurrentBudget.TryAcquire(weight) {
-		return nil, false
-	}
-	return func() { h.wsConcurrentBudget.Release(weight) }, true
-}
-
-func (h *handler) respondServerBusy(msg *jsonrpcMessage) {
-	if msg.isNotification() {
-		return
-	}
-	resp := msg.errorResponse(&internalServerError{errcodeServerBusy, errMsgServerBusy})
-	h.conn.writeJSON(h.rootCtx, resp, true)
-}
-
-func (h *handler) respondBatchServerBusy(calls []*jsonrpcMessage) {
-	busy := &internalServerError{errcodeServerBusy, errMsgServerBusy}
-	resp := make([]*jsonrpcMessage, 0, len(calls))
-	for _, msg := range calls {
-		if !msg.isNotification() {
-			resp = append(resp, msg.errorResponse(busy))
+	switch {
+	case weight < h.readLimit:
+		h.wsConcurrentBudget.Release(h.readLimit - weight)
+	case weight > h.readLimit:
+		ctx, cancel := context.WithTimeout(ctx, wsAdmissionTimeout)
+		defer cancel()
+		if err := h.wsConcurrentBudget.Acquire(ctx, weight-h.readLimit); err != nil {
+			return nil, fmt.Errorf("concurrent request byte budget exhausted: %w", err)
 		}
 	}
-	if len(resp) == 0 {
-		return
-	}
-	h.conn.writeJSON(h.rootCtx, resp, true)
+	return func() { h.wsConcurrentBudget.Release(weight) }, nil
 }
 
 // batchCallBuffer manages in progress call messages and their responses during a batch
@@ -209,10 +235,14 @@ func (b *batchCallBuffer) doWrite(ctx context.Context, conn jsonWriter, isErrorR
 }
 
 // handleBatch executes all messages in a batch and returns the responses.
-func (h *handler) handleBatch(msgs []*jsonrpcMessage, rawLen int64) {
+func (h *handler) handleBatch(msgs []*jsonrpcMessage, release func()) {
+	if release == nil {
+		release = func() {}
+	}
 	// Emit error response for empty batches:
 	if len(msgs) == 0 {
 		h.startCallProc(func(cp *callProc) {
+			defer release()
 			resp := errorMessage(&invalidRequestError{"empty batch"})
 			h.conn.writeJSON(cp.ctx, resp, true)
 		})
@@ -221,6 +251,7 @@ func (h *handler) handleBatch(msgs []*jsonrpcMessage, rawLen int64) {
 	// Apply limit on total number of requests.
 	if h.batchRequestLimit != 0 && len(msgs) > h.batchRequestLimit {
 		h.startCallProc(func(cp *callProc) {
+			defer release()
 			h.respondWithBatchTooLarge(cp, msgs)
 		})
 		return
@@ -233,18 +264,12 @@ func (h *handler) handleBatch(msgs []*jsonrpcMessage, rawLen int64) {
 		calls = append(calls, msg)
 	})
 	if len(calls) == 0 {
-		return
-	}
-
-	release, ok := h.tryAcquireRequestBytes(rawLen)
-	if !ok {
-		h.respondBatchServerBusy(calls)
+		release()
 		return
 	}
 
 	// Process calls on a goroutine because they may block indefinitely:
 	h.startCallProc(func(cp *callProc) {
-		defer release()
 		var (
 			timer      *time.Timer
 			cancel     context.CancelFunc
@@ -291,6 +316,7 @@ func (h *handler) handleBatch(msgs []*jsonrpcMessage, rawLen int64) {
 		}
 
 		h.addSubscriptions(cp.notifiers)
+		release()
 		callBuffer.write(cp.ctx, h.conn)
 		for _, n := range cp.notifiers {
 			n.activate()
@@ -313,22 +339,27 @@ func (h *handler) respondWithBatchTooLarge(cp *callProc, batch []*jsonrpcMessage
 }
 
 // handleMsg handles a single non-batch message.
-func (h *handler) handleMsg(msg *jsonrpcMessage, rawLen int64) {
+func (h *handler) handleMsg(msg *jsonrpcMessage, release func()) {
+	if release == nil {
+		release = func() {}
+	}
 	msgs := []*jsonrpcMessage{msg}
+	var callStarted bool
 	h.handleResponses(msgs, func(msg *jsonrpcMessage) {
-		release, ok := h.tryAcquireRequestBytes(rawLen)
-		if !ok {
-			h.respondServerBusy(msg)
-			return
-		}
+		callStarted = true
 		h.startCallProc(func(cp *callProc) {
-			defer release()
-			h.handleNonBatchCall(cp, msg)
+			h.handleNonBatchCall(cp, msg, release)
 		})
 	})
+	if !callStarted {
+		release()
+	}
 }
 
-func (h *handler) handleNonBatchCall(cp *callProc, msg *jsonrpcMessage) {
+func (h *handler) handleNonBatchCall(cp *callProc, msg *jsonrpcMessage, release func()) {
+	if release == nil {
+		release = func() {}
+	}
 	var (
 		responded sync.Once
 		timer     *time.Timer
@@ -355,6 +386,7 @@ func (h *handler) handleNonBatchCall(cp *callProc, msg *jsonrpcMessage) {
 		timer.Stop()
 	}
 	h.addSubscriptions(cp.notifiers)
+	release()
 	if answer != nil {
 		responded.Do(func() {
 			h.conn.writeJSON(cp.ctx, answer, false)

--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/log"
+	"golang.org/x/sync/semaphore"
 )
 
 // handler handles JSON-RPC messages. There is one handler per connection. Note that
@@ -65,6 +66,8 @@ type handler struct {
 	allowSubscribe       bool
 	batchRequestLimit    int
 	batchResponseMaxSize int
+	wsConcurrentBudget   *semaphore.Weighted
+	readLimit            int64
 
 	subLock    sync.Mutex
 	serverSubs map[ID]*Subscription
@@ -75,7 +78,7 @@ type callProc struct {
 	notifiers []*Notifier
 }
 
-func newHandler(connCtx context.Context, conn jsonWriter, idgen func() ID, reg *serviceRegistry, batchRequestLimit, batchResponseMaxSize int) *handler {
+func newHandler(connCtx context.Context, conn jsonWriter, idgen func() ID, reg *serviceRegistry, batchRequestLimit, batchResponseMaxSize int, wsConcurrentBudget *semaphore.Weighted, readLimit int64) *handler {
 	rootCtx, cancelRoot := context.WithCancel(connCtx)
 	h := &handler{
 		reg:                  reg,
@@ -90,12 +93,48 @@ func newHandler(connCtx context.Context, conn jsonWriter, idgen func() ID, reg *
 		log:                  log.Root(),
 		batchRequestLimit:    batchRequestLimit,
 		batchResponseMaxSize: batchResponseMaxSize,
+		wsConcurrentBudget:   wsConcurrentBudget,
+		readLimit:            readLimit,
 	}
 	if conn.remoteAddr() != "" {
 		h.log = h.log.New("conn", conn.remoteAddr())
 	}
 	h.unsubscribeCb = newCallback(reflect.Value{}, reflect.ValueOf(h.unsubscribe))
 	return h
+}
+
+func (h *handler) tryAcquireRequestBytes(rawLen int64) (release func(), ok bool) {
+	if h.wsConcurrentBudget == nil {
+		return func() {}, true
+	}
+	weight := rawLen
+	if weight <= 0 {
+		weight = h.readLimit
+	}
+	if !h.wsConcurrentBudget.TryAcquire(weight) {
+		return nil, false
+	}
+	return func() { h.wsConcurrentBudget.Release(weight) }, true
+}
+
+func (h *handler) respondServerBusy(msg *jsonrpcMessage) {
+	h.startCallProc(func(cp *callProc) {
+		resp := msg.errorResponse(&internalServerError{errcodeServerBusy, errMsgServerBusy})
+		h.conn.writeJSON(cp.ctx, resp, true)
+	})
+}
+
+func (h *handler) respondBatchServerBusy(calls []*jsonrpcMessage) {
+	h.startCallProc(func(cp *callProc) {
+		resp := errorMessage(&internalServerError{errcodeServerBusy, errMsgServerBusy})
+		for _, msg := range calls {
+			if msg.isCall() {
+				resp.ID = msg.ID
+				break
+			}
+		}
+		h.conn.writeJSON(cp.ctx, []*jsonrpcMessage{resp}, true)
+	})
 }
 
 // batchCallBuffer manages in progress call messages and their responses during a batch
@@ -168,7 +207,7 @@ func (b *batchCallBuffer) doWrite(ctx context.Context, conn jsonWriter, isErrorR
 }
 
 // handleBatch executes all messages in a batch and returns the responses.
-func (h *handler) handleBatch(msgs []*jsonrpcMessage) {
+func (h *handler) handleBatch(msgs []*jsonrpcMessage, rawLen int64) {
 	// Emit error response for empty batches:
 	if len(msgs) == 0 {
 		h.startCallProc(func(cp *callProc) {
@@ -195,8 +234,15 @@ func (h *handler) handleBatch(msgs []*jsonrpcMessage) {
 		return
 	}
 
+	release, ok := h.tryAcquireRequestBytes(rawLen)
+	if !ok {
+		h.respondBatchServerBusy(calls)
+		return
+	}
+
 	// Process calls on a goroutine because they may block indefinitely:
 	h.startCallProc(func(cp *callProc) {
+		defer release()
 		var (
 			timer      *time.Timer
 			cancel     context.CancelFunc
@@ -265,10 +311,16 @@ func (h *handler) respondWithBatchTooLarge(cp *callProc, batch []*jsonrpcMessage
 }
 
 // handleMsg handles a single non-batch message.
-func (h *handler) handleMsg(msg *jsonrpcMessage) {
+func (h *handler) handleMsg(msg *jsonrpcMessage, rawLen int64) {
 	msgs := []*jsonrpcMessage{msg}
 	h.handleResponses(msgs, func(msg *jsonrpcMessage) {
+		release, ok := h.tryAcquireRequestBytes(rawLen)
+		if !ok {
+			h.respondServerBusy(msg)
+			return
+		}
 		h.startCallProc(func(cp *callProc) {
+			defer release()
 			h.handleNonBatchCall(cp, msg)
 		})
 	})

--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -121,26 +121,22 @@ func (h *handler) respondServerBusy(msg *jsonrpcMessage) {
 	if msg.isNotification() {
 		return
 	}
-	h.startCallProc(func(cp *callProc) {
-		resp := msg.errorResponse(&internalServerError{errcodeServerBusy, errMsgServerBusy})
-		h.conn.writeJSON(cp.ctx, resp, true)
-	})
+	resp := msg.errorResponse(&internalServerError{errcodeServerBusy, errMsgServerBusy})
+	h.conn.writeJSON(h.rootCtx, resp, true)
 }
 
 func (h *handler) respondBatchServerBusy(calls []*jsonrpcMessage) {
-	h.startCallProc(func(cp *callProc) {
-		busy := &internalServerError{errcodeServerBusy, errMsgServerBusy}
-		resp := make([]*jsonrpcMessage, 0, len(calls))
-		for _, msg := range calls {
-			if !msg.isNotification() {
-				resp = append(resp, msg.errorResponse(busy))
-			}
+	busy := &internalServerError{errcodeServerBusy, errMsgServerBusy}
+	resp := make([]*jsonrpcMessage, 0, len(calls))
+	for _, msg := range calls {
+		if !msg.isNotification() {
+			resp = append(resp, msg.errorResponse(busy))
 		}
-		if len(resp) == 0 {
-			return
-		}
-		h.conn.writeJSON(cp.ctx, resp, true)
-	})
+	}
+	if len(resp) == 0 {
+		return
+	}
+	h.conn.writeJSON(h.rootCtx, resp, true)
 }
 
 // batchCallBuffer manages in progress call messages and their responses during a batch

--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -165,6 +165,27 @@ func (h *handler) commitFrameBudget(ctx context.Context, rawLen int64) (release 
 	return func() { h.wsConcurrentBudget.Release(weight) }, nil
 }
 
+// frameBudgetExceededResponse builds the JSON-RPC error response for a frame that decoded
+// successfully but could not be admitted under the concurrent request-byte budget.
+func frameBudgetExceededResponse(msgs []*jsonrpcMessage, batch bool) interface{} {
+	err := &internalServerError{errcodeRequestTooLarge, errMsgRequestTooLarge}
+	if !batch {
+		msg := msgs[0]
+		if msg.isNotification() {
+			return nil
+		}
+		return msg.errorResponse(err)
+	}
+	resp := errorMessage(err)
+	for _, msg := range msgs {
+		if msg.isCall() {
+			resp.ID = msg.ID
+			break
+		}
+	}
+	return []*jsonrpcMessage{resp}
+}
+
 // batchCallBuffer manages in progress call messages and their responses during a batch
 // call. Calls need to be synchronized between the processing and timeout-triggering
 // goroutines.

--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -118,6 +118,9 @@ func (h *handler) tryAcquireRequestBytes(rawLen int64) (release func(), ok bool)
 }
 
 func (h *handler) respondServerBusy(msg *jsonrpcMessage) {
+	if msg.isNotification() {
+		return
+	}
 	h.startCallProc(func(cp *callProc) {
 		resp := msg.errorResponse(&internalServerError{errcodeServerBusy, errMsgServerBusy})
 		h.conn.writeJSON(cp.ctx, resp, true)
@@ -126,14 +129,17 @@ func (h *handler) respondServerBusy(msg *jsonrpcMessage) {
 
 func (h *handler) respondBatchServerBusy(calls []*jsonrpcMessage) {
 	h.startCallProc(func(cp *callProc) {
-		resp := errorMessage(&internalServerError{errcodeServerBusy, errMsgServerBusy})
+		busy := &internalServerError{errcodeServerBusy, errMsgServerBusy}
+		resp := make([]*jsonrpcMessage, 0, len(calls))
 		for _, msg := range calls {
-			if msg.isCall() {
-				resp.ID = msg.ID
-				break
+			if !msg.isNotification() {
+				resp = append(resp, msg.errorResponse(busy))
 			}
 		}
-		h.conn.writeJSON(cp.ctx, []*jsonrpcMessage{resp}, true)
+		if len(resp) == 0 {
+			return
+		}
+		h.conn.writeJSON(cp.ctx, resp, true)
 	})
 }
 

--- a/rpc/http.go
+++ b/rpc/http.go
@@ -66,9 +66,9 @@ func (hc *httpConn) remoteAddr() string {
 	return hc.url
 }
 
-func (hc *httpConn) readBatch() ([]*jsonrpcMessage, bool, error) {
+func (hc *httpConn) readBatch() ([]*jsonrpcMessage, bool, int64, error) {
 	<-hc.closeCh
-	return nil, false, io.EOF
+	return nil, false, 0, io.EOF
 }
 
 func (hc *httpConn) close() {

--- a/rpc/json.go
+++ b/rpc/json.go
@@ -229,12 +229,12 @@ func (c *jsonCodec) remoteAddr() string {
 	return c.remote
 }
 
-func (c *jsonCodec) readBatch() (messages []*jsonrpcMessage, batch bool, err error) {
+func (c *jsonCodec) readBatch() (messages []*jsonrpcMessage, batch bool, rawLen int64, err error) {
 	// Decode the next JSON object in the input stream.
 	// This verifies basic syntax, etc.
 	var rawmsg json.RawMessage
 	if err := c.decode(&rawmsg); err != nil {
-		return nil, false, err
+		return nil, false, 0, err
 	}
 	messages, batch = parseMessage(rawmsg)
 	for i, msg := range messages {
@@ -244,7 +244,7 @@ func (c *jsonCodec) readBatch() (messages []*jsonrpcMessage, batch bool, err err
 			messages[i] = new(jsonrpcMessage)
 		}
 	}
-	return messages, batch, nil
+	return messages, batch, int64(len(rawmsg)), nil
 }
 
 func (c *jsonCodec) writeJSON(ctx context.Context, v interface{}, isErrorResponse bool) error {

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -49,12 +49,12 @@ type Server struct {
 	services serviceRegistry
 	idgen    func() ID
 
-	mutex              sync.Mutex
-	codecs             map[ServerCodec]struct{}
-	denyList           map[string]struct{}
-	run                atomic.Bool
-	batchItemLimit     int
-	batchResponseLimit int
+	mutex                    sync.Mutex
+	codecs                   map[ServerCodec]struct{}
+	denyList                 map[string]struct{}
+	run                      atomic.Bool
+	batchItemLimit           int
+	batchResponseLimit       int
 	httpBodyLimit            int
 	readLimit                int64
 	wsConcurrentRequestBytes int64 // configured limit; 0 disables
@@ -106,18 +106,7 @@ func (s *Server) SetReadLimits(limit int64) {
 
 // SetWSConcurrentRequestBytes bounds the total size, in bytes, of JSON-RPC request
 // frames on persistent connections (WebSocket, IPC, stdio) that may be read and
-// processed concurrently, weighted by each frame's size. Budget is reserved before a
-// frame is read (using the read limit as a worst-case estimate) and tightened to the
-// frame's actual size once known, so the byte cost of decoding is bounded by the
-// budget too, not just handler execution. When the budget is exhausted, further
-// frames are not read from the connection until in-flight work releases its
-// reservation (read-side backpressure); there is no more per-request rejection
-// response, since a frame's request ID isn't known until after it's decoded. If a
-// connection cannot acquire budget within wsAdmissionTimeout, it is torn down rather
-// than left blocked indefinitely. Set to 0 to disable the limit. If limit is positive
-// and smaller than the current read limit (SetReadLimits), it is raised to the read
-// limit so a single maximum-size frame can always be admitted.
-//
+// processed concurrently, weighted by each frame's size. Set to 0 to disable the limit.
 // This method should be called before processing any requests via Websocket server.
 func (s *Server) SetWSConcurrentRequestBytes(limit int64) {
 	s.wsConcurrentRequestBytes = limit

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -104,12 +104,19 @@ func (s *Server) SetReadLimits(limit int64) {
 	s.recomputeWSConcurrentBudget()
 }
 
-// SetWSConcurrentRequestBytes bounds the total size, in bytes, of WebSocket JSON-RPC
-// request frames admitted for processing concurrently, weighted by each frame's size.
-// Requests that would exceed the budget are rejected before handler dispatch.
-// Set to 0 to disable the limit. If limit is positive and smaller than the current
-// read limit (SetReadLimits), it is raised to the read limit so a single maximum-size
-// frame can always be admitted.
+// SetWSConcurrentRequestBytes bounds the total size, in bytes, of JSON-RPC request
+// frames on persistent connections (WebSocket, IPC, stdio) that may be read and
+// processed concurrently, weighted by each frame's size. Budget is reserved before a
+// frame is read (using the read limit as a worst-case estimate) and tightened to the
+// frame's actual size once known, so the byte cost of decoding is bounded by the
+// budget too, not just handler execution. When the budget is exhausted, further
+// frames are not read from the connection until in-flight work releases its
+// reservation (read-side backpressure); there is no more per-request rejection
+// response, since a frame's request ID isn't known until after it's decoded. If a
+// connection cannot acquire budget within wsAdmissionTimeout, it is torn down rather
+// than left blocked indefinitely. Set to 0 to disable the limit. If limit is positive
+// and smaller than the current read limit (SetReadLimits), it is raised to the read
+// limit so a single maximum-size frame can always be admitted.
 //
 // This method should be called before processing any requests via Websocket server.
 func (s *Server) SetWSConcurrentRequestBytes(limit int64) {
@@ -199,7 +206,7 @@ func (s *Server) serveSingleRequest(ctx context.Context, codec ServerCodec) {
 	h.allowSubscribe = false
 	defer h.close(io.EOF, nil)
 
-	reqs, batch, rawLen, err := codec.readBatch()
+	reqs, batch, _, err := codec.readBatch()
 	if err != nil {
 		if msg := messageForReadError(err); msg != "" {
 			resp := errorMessage(&invalidMessageError{msg})
@@ -217,9 +224,9 @@ func (s *Server) serveSingleRequest(ctx context.Context, codec ServerCodec) {
 		}
 	}
 	if batch {
-		h.handleBatch(reqs, rawLen)
+		h.handleBatch(reqs, func() {})
 	} else {
-		h.handleMsg(reqs[0], rawLen)
+		h.handleMsg(reqs[0], func() {})
 	}
 }
 

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -55,9 +55,10 @@ type Server struct {
 	run                atomic.Bool
 	batchItemLimit     int
 	batchResponseLimit int
-	httpBodyLimit      int
-	readLimit          int64
-	wsConcurrentBudget *semaphore.Weighted
+	httpBodyLimit            int
+	readLimit                int64
+	wsConcurrentRequestBytes int64 // configured limit; 0 disables
+	wsConcurrentBudget       *semaphore.Weighted
 }
 
 // NewServer creates a new server instance with no registered handlers.
@@ -100,6 +101,7 @@ func (s *Server) SetHTTPBodyLimit(limit int) {
 // This method should be called before processing any requests via Websocket server.
 func (s *Server) SetReadLimits(limit int64) {
 	s.readLimit = limit
+	s.recomputeWSConcurrentBudget()
 }
 
 // SetWSConcurrentRequestBytes bounds the total size, in bytes, of WebSocket JSON-RPC
@@ -111,6 +113,12 @@ func (s *Server) SetReadLimits(limit int64) {
 //
 // This method should be called before processing any requests via Websocket server.
 func (s *Server) SetWSConcurrentRequestBytes(limit int64) {
+	s.wsConcurrentRequestBytes = limit
+	s.recomputeWSConcurrentBudget()
+}
+
+func (s *Server) recomputeWSConcurrentBudget() {
+	limit := s.wsConcurrentRequestBytes
 	if limit <= 0 {
 		s.wsConcurrentBudget = nil
 		return

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -25,6 +25,7 @@ import (
 	"sync/atomic"
 
 	"github.com/ethereum/go-ethereum/log"
+	"golang.org/x/sync/semaphore"
 )
 
 const MetadataApi = "rpc"
@@ -56,6 +57,7 @@ type Server struct {
 	batchResponseLimit int
 	httpBodyLimit      int
 	readLimit          int64
+	wsConcurrentBudget *semaphore.Weighted
 }
 
 // NewServer creates a new server instance with no registered handlers.
@@ -100,6 +102,25 @@ func (s *Server) SetReadLimits(limit int64) {
 	s.readLimit = limit
 }
 
+// SetWSConcurrentRequestBytes bounds the total size, in bytes, of WebSocket JSON-RPC
+// request frames admitted for processing concurrently, weighted by each frame's size.
+// Requests that would exceed the budget are rejected before handler dispatch.
+// Set to 0 to disable the limit. If limit is positive and smaller than the current
+// read limit (SetReadLimits), it is raised to the read limit so a single maximum-size
+// frame can always be admitted.
+//
+// This method should be called before processing any requests via Websocket server.
+func (s *Server) SetWSConcurrentRequestBytes(limit int64) {
+	if limit <= 0 {
+		s.wsConcurrentBudget = nil
+		return
+	}
+	if s.readLimit > 0 && limit < s.readLimit {
+		limit = s.readLimit
+	}
+	s.wsConcurrentBudget = semaphore.NewWeighted(limit)
+}
+
 // RegisterName creates a service for the given receiver type under the given name. When no
 // methods on the given receiver match the criteria to be either an RPC method or a
 // subscription an error is returned. Otherwise a new service is created and added to the
@@ -131,6 +152,8 @@ func (s *Server) ServeCodec(codec ServerCodec, options CodecOption) {
 		idgen:              s.idgen,
 		batchItemLimit:     s.batchItemLimit,
 		batchResponseLimit: s.batchResponseLimit,
+		wsConcurrentBudget: s.wsConcurrentBudget,
+		readLimit:          s.readLimit,
 	}
 	c := initClient(codec, &s.services, cfg)
 	<-codec.closed()
@@ -164,11 +187,11 @@ func (s *Server) serveSingleRequest(ctx context.Context, codec ServerCodec) {
 		return
 	}
 
-	h := newHandler(ctx, codec, s.idgen, &s.services, s.batchItemLimit, s.batchResponseLimit)
+	h := newHandler(ctx, codec, s.idgen, &s.services, s.batchItemLimit, s.batchResponseLimit, nil, s.readLimit)
 	h.allowSubscribe = false
 	defer h.close(io.EOF, nil)
 
-	reqs, batch, err := codec.readBatch()
+	reqs, batch, rawLen, err := codec.readBatch()
 	if err != nil {
 		if msg := messageForReadError(err); msg != "" {
 			resp := errorMessage(&invalidMessageError{msg})
@@ -186,9 +209,9 @@ func (s *Server) serveSingleRequest(ctx context.Context, codec ServerCodec) {
 		}
 	}
 	if batch {
-		h.handleBatch(reqs)
+		h.handleBatch(reqs, rawLen)
 	} else {
-		h.handleMsg(reqs[0])
+		h.handleMsg(reqs[0], rawLen)
 	}
 }
 

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -42,7 +42,7 @@ type API struct {
 // multiple go-routines concurrently.
 type ServerCodec interface {
 	peerInfo() PeerInfo
-	readBatch() (msgs []*jsonrpcMessage, isBatch bool, err error)
+	readBatch() (msgs []*jsonrpcMessage, isBatch bool, rawLen int64, err error)
 	close()
 
 	jsonWriter

--- a/rpc/ws_admission_test.go
+++ b/rpc/ws_admission_test.go
@@ -13,28 +13,45 @@ import (
 func TestWSConcurrentRequestBytes(t *testing.T) {
 	t.Parallel()
 
+	const (
+		sleepDuration = 200 * time.Millisecond
+		pad           = 48
+	)
+
 	srv := newTestServer()
-	defer srv.Stop()
 
 	p1, p2 := net.Pipe()
-	defer p1.Close()
-	defer p2.Close()
 
-	payload := fmt.Sprintf(
-		`{"jsonrpc":"2.0","id":%d,"method":"test_block","_pad":"%s"}`,
-		1, strings.Repeat("x", 48),
-	)
+	makeMsg := func(id int) string {
+		return fmt.Sprintf(
+			`{"jsonrpc":"2.0","id":%d,"method":"test_sleep","params":["200ms"],"_pad":"%s"}`,
+			id, strings.Repeat("x", pad),
+		)
+	}
+	payload := makeMsg(1)
 	frameSize := int64(len(payload))
 	srv.SetReadLimits(frameSize)
 	srv.SetWSConcurrentRequestBytes(frameSize)
 
-	go srv.ServeCodec(NewCodec(p1), 0)
+	serveDone := make(chan struct{})
+	go func() {
+		srv.ServeCodec(NewCodec(p1), 0)
+		close(serveDone)
+	}()
+
+	t.Cleanup(func() {
+		p2.Close()
+		p1.Close()
+		select {
+		case <-serveDone:
+		case <-time.After(2 * time.Second):
+			t.Error("ServeCodec did not exit within 2s")
+		}
+		srv.Stop()
+	})
 
 	writeReq := func(id int) {
-		msg := fmt.Sprintf(
-			`{"jsonrpc":"2.0","id":%d,"method":"test_block","_pad":"%s"}`,
-			id, strings.Repeat("x", 48),
-		)
+		msg := makeMsg(id)
 		if len(msg) != len(payload) {
 			t.Fatalf("unexpected payload size %d != %d", len(msg), len(payload))
 		}
@@ -43,18 +60,16 @@ func TestWSConcurrentRequestBytes(t *testing.T) {
 		}
 	}
 
-	// One in-flight request exhausts the budget; the next is rejected before dispatch.
+	// One in-flight sleep holds the budget; the next frame is rejected before dispatch.
 	writeReq(1)
 	writeReq(2)
 
 	dec := json.NewDecoder(p2)
-	deadline := time.After(5 * time.Second)
+	deadline := time.Now().Add(5 * time.Second)
 	gotBusy := false
 	for !gotBusy {
-		select {
-		case <-deadline:
+		if time.Now().After(deadline) {
 			t.Fatal("timed out waiting for server busy response")
-		default:
 		}
 		var resp jsonrpcMessage
 		if err := dec.Decode(&resp); err != nil {
@@ -64,6 +79,14 @@ func TestWSConcurrentRequestBytes(t *testing.T) {
 			gotBusy = true
 		}
 	}
+
+	// Let the in-flight sleep finish and release its budget before pipe teardown.
+	_ = p2.SetReadDeadline(time.Now().Add(sleepDuration + 500*time.Millisecond))
+	var sleepResp jsonrpcMessage
+	if err := dec.Decode(&sleepResp); err != nil {
+		t.Fatalf("decode sleep response: %v", err)
+	}
+	_ = p2.SetReadDeadline(time.Time{})
 }
 
 func TestSetWSConcurrentRequestBytesRaisesToReadLimit(t *testing.T) {

--- a/rpc/ws_admission_test.go
+++ b/rpc/ws_admission_test.go
@@ -148,3 +148,57 @@ func TestSetReadLimitsRecomputesConcurrentBudget(t *testing.T) {
 	}
 	srv.wsConcurrentBudget.Release(500)
 }
+
+// TestFrameBudgetExceededResponse covers the response written when a frame decodes
+// successfully but exceeds the concurrent request-byte budget.
+func TestFrameBudgetExceededResponse(t *testing.T) {
+	t.Parallel()
+
+	call := &jsonrpcMessage{Version: vsn, ID: json.RawMessage("1"), Method: "test_method"}
+	notification := &jsonrpcMessage{Version: vsn, Method: "test_method"}
+
+	t.Run("call", func(t *testing.T) {
+		resp := frameBudgetExceededResponse([]*jsonrpcMessage{call}, false)
+		msg, ok := resp.(*jsonrpcMessage)
+		if !ok {
+			t.Fatalf("expected *jsonrpcMessage, got %T", resp)
+		}
+		if msg.Error == nil || msg.Error.Code != errcodeRequestTooLarge {
+			t.Fatalf("expected error code %d, got %+v", errcodeRequestTooLarge, msg.Error)
+		}
+		if string(msg.ID) != string(call.ID) {
+			t.Fatalf("expected response id %s, got %s", call.ID, msg.ID)
+		}
+	})
+
+	t.Run("notification", func(t *testing.T) {
+		if resp := frameBudgetExceededResponse([]*jsonrpcMessage{notification}, false); resp != nil {
+			t.Fatalf("expected no response for a notification, got %v", resp)
+		}
+	})
+
+	t.Run("batch", func(t *testing.T) {
+		resp := frameBudgetExceededResponse([]*jsonrpcMessage{notification, call}, true)
+		batch, ok := resp.([]*jsonrpcMessage)
+		if !ok || len(batch) != 1 {
+			t.Fatalf("expected a single-element batch response, got %T: %v", resp, resp)
+		}
+		if batch[0].Error == nil || batch[0].Error.Code != errcodeRequestTooLarge {
+			t.Fatalf("expected error code %d, got %+v", errcodeRequestTooLarge, batch[0].Error)
+		}
+		if string(batch[0].ID) != string(call.ID) {
+			t.Fatalf("expected response tagged with the call's id %s, got %s", call.ID, batch[0].ID)
+		}
+	})
+
+	t.Run("batch with no calls", func(t *testing.T) {
+		resp := frameBudgetExceededResponse([]*jsonrpcMessage{notification}, true)
+		batch, ok := resp.([]*jsonrpcMessage)
+		if !ok || len(batch) != 1 {
+			t.Fatalf("expected a single-element batch response, got %T: %v", resp, resp)
+		}
+		if string(batch[0].ID) != string(null) {
+			t.Fatalf("expected null id when no call is present, got %s", batch[0].ID)
+		}
+	})
+}

--- a/rpc/ws_admission_test.go
+++ b/rpc/ws_admission_test.go
@@ -10,6 +10,39 @@ import (
 	"time"
 )
 
+func TestWSConcurrentRequestBytesSingleInFlight(t *testing.T) {
+	t.Parallel()
+
+	const pad = 48
+	srv := newTestServer()
+	p1, p2 := net.Pipe()
+	sleepDuration := 50 * time.Millisecond
+	makeMsg := func(id int) string {
+		return fmt.Sprintf(
+			`{"jsonrpc":"2.0","id":%d,"method":"test_sleep","params":[%d],"_pad":"%s"}`,
+			id, sleepDuration.Nanoseconds(), strings.Repeat("x", pad),
+		)
+	}
+	payload := makeMsg(1)
+	frameSize := int64(len(payload))
+	srv.SetReadLimits(frameSize)
+	srv.SetWSConcurrentRequestBytes(frameSize)
+	go srv.ServeCodec(NewCodec(p1), 0)
+	t.Cleanup(func() { p2.Close(); p1.Close(); srv.Stop() })
+	if _, err := io.WriteString(p2, payload); err != nil {
+		t.Fatal(err)
+	}
+	dec := json.NewDecoder(p2)
+	_ = p2.SetReadDeadline(time.Now().Add(time.Second))
+	var resp jsonrpcMessage
+	if err := dec.Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %v", resp.Error)
+	}
+}
+
 func TestWSConcurrentRequestBytes(t *testing.T) {
 	t.Parallel()
 
@@ -24,8 +57,8 @@ func TestWSConcurrentRequestBytes(t *testing.T) {
 
 	makeMsg := func(id int) string {
 		return fmt.Sprintf(
-			`{"jsonrpc":"2.0","id":%d,"method":"test_sleep","params":["200ms"],"_pad":"%s"}`,
-			id, strings.Repeat("x", pad),
+			`{"jsonrpc":"2.0","id":%d,"method":"test_sleep","params":[%d],"_pad":"%s"}`,
+			id, sleepDuration.Nanoseconds(), strings.Repeat("x", pad),
 		)
 	}
 	payload := makeMsg(1)
@@ -60,31 +93,28 @@ func TestWSConcurrentRequestBytes(t *testing.T) {
 		}
 	}
 
-	// One in-flight sleep holds the budget; the next frame is rejected before dispatch.
+	// Budget holds through handler work; the second frame is not read until then.
 	writeReq(1)
 	writeReq(2)
 
 	dec := json.NewDecoder(p2)
-	deadline := time.Now().Add(5 * time.Second)
-	gotBusy := false
-	for !gotBusy {
-		if time.Now().After(deadline) {
-			t.Fatal("timed out waiting for server busy response")
-		}
-		var resp jsonrpcMessage
-		if err := dec.Decode(&resp); err != nil {
-			t.Fatalf("decode response: %v", err)
-		}
-		if resp.Error != nil && resp.Error.Code == errcodeServerBusy {
-			gotBusy = true
-		}
+
+	_ = p2.SetReadDeadline(time.Now().Add(sleepDuration + time.Second))
+	var firstResp jsonrpcMessage
+	if err := dec.Decode(&firstResp); err != nil {
+		t.Fatalf("decode first response: %v", err)
+	}
+	if string(firstResp.ID) != "1" {
+		t.Fatalf("expected first response id 1, got %s", string(firstResp.ID))
 	}
 
-	// Let the in-flight sleep finish and release its budget before pipe teardown.
-	_ = p2.SetReadDeadline(time.Now().Add(sleepDuration + 500*time.Millisecond))
-	var sleepResp jsonrpcMessage
-	if err := dec.Decode(&sleepResp); err != nil {
-		t.Fatalf("decode sleep response: %v", err)
+	_ = p2.SetReadDeadline(time.Now().Add(sleepDuration + time.Second))
+	var secondResp jsonrpcMessage
+	if err := dec.Decode(&secondResp); err != nil {
+		t.Fatalf("decode second response: %v", err)
+	}
+	if string(secondResp.ID) != "2" {
+		t.Fatalf("expected second response id 2, got %s", string(secondResp.ID))
 	}
 	_ = p2.SetReadDeadline(time.Time{})
 }

--- a/rpc/ws_admission_test.go
+++ b/rpc/ws_admission_test.go
@@ -1,0 +1,82 @@
+package rpc
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestWSConcurrentRequestBytes(t *testing.T) {
+	t.Parallel()
+
+	srv := newTestServer()
+	defer srv.Stop()
+
+	p1, p2 := net.Pipe()
+	defer p1.Close()
+	defer p2.Close()
+
+	payload := fmt.Sprintf(
+		`{"jsonrpc":"2.0","id":%d,"method":"test_block","_pad":"%s"}`,
+		1, strings.Repeat("x", 48),
+	)
+	frameSize := int64(len(payload))
+	srv.SetReadLimits(frameSize)
+	srv.SetWSConcurrentRequestBytes(frameSize)
+
+	go srv.ServeCodec(NewCodec(p1), 0)
+
+	writeReq := func(id int) {
+		msg := fmt.Sprintf(
+			`{"jsonrpc":"2.0","id":%d,"method":"test_block","_pad":"%s"}`,
+			id, strings.Repeat("x", 48),
+		)
+		if len(msg) != len(payload) {
+			t.Fatalf("unexpected payload size %d != %d", len(msg), len(payload))
+		}
+		if _, err := io.WriteString(p2, msg); err != nil {
+			t.Fatalf("write request %d: %v", id, err)
+		}
+	}
+
+	// One in-flight request exhausts the budget; the next is rejected before dispatch.
+	writeReq(1)
+	writeReq(2)
+
+	dec := json.NewDecoder(p2)
+	deadline := time.After(5 * time.Second)
+	gotBusy := false
+	for !gotBusy {
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for server busy response")
+		default:
+		}
+		var resp jsonrpcMessage
+		if err := dec.Decode(&resp); err != nil {
+			t.Fatalf("decode response: %v", err)
+		}
+		if resp.Error != nil && resp.Error.Code == errcodeServerBusy {
+			gotBusy = true
+		}
+	}
+}
+
+func TestSetWSConcurrentRequestBytesRaisesToReadLimit(t *testing.T) {
+	t.Parallel()
+
+	srv := NewServer()
+	srv.SetReadLimits(500)
+	srv.SetWSConcurrentRequestBytes(100)
+	if srv.wsConcurrentBudget == nil {
+		t.Fatal("expected budget to be configured")
+	}
+	if !srv.wsConcurrentBudget.TryAcquire(500) {
+		t.Fatal("budget should allow a single max-size frame")
+	}
+	srv.wsConcurrentBudget.Release(500)
+}

--- a/rpc/ws_admission_test.go
+++ b/rpc/ws_admission_test.go
@@ -80,3 +80,18 @@ func TestSetWSConcurrentRequestBytesRaisesToReadLimit(t *testing.T) {
 	}
 	srv.wsConcurrentBudget.Release(500)
 }
+
+func TestSetReadLimitsRecomputesConcurrentBudget(t *testing.T) {
+	t.Parallel()
+
+	srv := NewServer()
+	srv.SetWSConcurrentRequestBytes(100)
+	srv.SetReadLimits(500)
+	if srv.wsConcurrentBudget == nil {
+		t.Fatal("expected budget to be configured")
+	}
+	if !srv.wsConcurrentBudget.TryAcquire(500) {
+		t.Fatal("budget should be recomputed when read limit increases")
+	}
+	srv.wsConcurrentBudget.Release(500)
+}


### PR DESCRIPTION
## Summary

Follow-up to sei-chain PLT-295 / PR #3648 (work-breakdown item **0r**). HTTP JSON-RPC got pre-decode request-size admission via `requestSizeLimiter`; the WebSocket plane had only a per-frame read cap (`SetReadLimits`) with no concurrent byte budget, so a single connection could pile up many large in-flight `eth_call` / `eth_estimateGas` simulations.

This PR adds a weighted byte budget for persistent JSON-RPC connections (WebSocket, IPC, stdio via `ServeCodec`):

- **`SetWSConcurrentRequestBytes(limit)`** — global concurrent frame-byte budget (0 disables). The effective budget is floored to `SetReadLimits`, so a single max-size frame can always be admitted, and is recomputed whenever either setter is called.
- **Read-side backpressure, not a busy error.** `Client.read` reserves budget worst-case (`acquirePreDecode`, weighted by `readLimit`) *before* decoding the next frame, then reconciles to the frame's actual size after decode (`commitFrameBudget`). If the budget is exhausted, the read loop blocks (bounded by `wsAdmissionTimeout`, 30s) instead of reading further frames — so a connection can't buffer unbounded in-flight work, and legitimate oversized-but-eventually-available frames aren't rejected outright.
- **`ServerCodec.readBatch()`** now also returns `rawLen` (raw frame byte count) so the reservation can be reconciled post-decode.
- **Release on completion** — a `release` callback threads through `handleMsg`/`handleBatch` and is invoked once the call (including async handler work) finishes, freeing the budget for the next frame.

HTTP single-request path (`serveSingleRequest`) is unchanged — sei-chain continues to enforce HTTP limits via `requestSizeLimiter`.

## sei-chain follow-up

After this merges and is tagged (e.g. `v1.15.7-sei-18`), sei-chain needs a small wiring PR:

- `MaxRequestBodyBytes` → `SetReadLimits` (replace hardcoded 10 MiB)
- `MaxConcurrentRequestBytes` → `SetWSConcurrentRequestBytes` in `EnableWS`
- bump `go.mod` replace

## Test plan

- [x] `go test ./rpc/...`
- [x] `TestWSConcurrentRequestBytesSingleInFlight` — single in-flight request is admitted and answered
- [x] `TestWSConcurrentRequestBytes` — second in-flight request is held (not read/answered) until the first releases its budget
- [x] `TestSetWSConcurrentRequestBytesRaisesToReadLimit` — budget floor vs read limit
- [x] `TestSetReadLimitsRecomputesConcurrentBudget` — budget recomputed when read limit changes after the concurrent limit is set
