### PR TITLE
rpc: add WebSocket admission rejection hook + configurable timeout

### DIFF
--- a/rpc/client.go
+++ b/rpc/client.go
@@ -92,6 +92,8 @@ type Client struct {
 	batchResponseMaxSize int
 	wsConcurrentBudget   *semaphore.Weighted
 	readLimit            int64
+	admissionEventHook   func(reason string)
+	wsAdmissionTimeout   time.Duration
 
 	// writeConn is used for writing to the connection on the caller's goroutine. It should
 	// only be accessed outside of dispatch, with the write lock held. The write lock is
@@ -123,7 +125,7 @@ func (c *Client) newClientConn(conn ServerCodec) *clientConn {
 	ctx := context.Background()
 	ctx = context.WithValue(ctx, clientContextKey{}, c)
 	ctx = context.WithValue(ctx, peerInfoContextKey{}, conn.peerInfo())
-	handler := newHandler(ctx, conn, c.idgen, c.services, c.batchItemLimit, c.batchResponseMaxSize, c.wsConcurrentBudget, c.readLimit)
+	handler := newHandler(ctx, conn, c.idgen, c.services, c.batchItemLimit, c.batchResponseMaxSize, c.wsConcurrentBudget, c.readLimit, c.admissionEventHook, c.wsAdmissionTimeout)
 	return &clientConn{conn, handler}
 }
 
@@ -254,6 +256,8 @@ func initClient(conn ServerCodec, services *serviceRegistry, cfg *clientConfig) 
 		batchResponseMaxSize: cfg.batchResponseLimit,
 		wsConcurrentBudget:   cfg.wsConcurrentBudget,
 		readLimit:            cfg.readLimit,
+		admissionEventHook:   cfg.admissionEventHook,
+		wsAdmissionTimeout:   cfg.wsAdmissionTimeout,
 		writeConn:            conn,
 		close:                make(chan struct{}),
 		closing:              make(chan struct{}),

--- a/rpc/client_opt.go
+++ b/rpc/client_opt.go
@@ -18,6 +18,7 @@ package rpc
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/gorilla/websocket"
 	"golang.org/x/sync/semaphore"
@@ -44,6 +45,8 @@ type clientConfig struct {
 	batchResponseLimit int
 	wsConcurrentBudget *semaphore.Weighted
 	readLimit          int64
+	admissionEventHook func(reason string)
+	wsAdmissionTimeout time.Duration
 }
 
 func (cfg *clientConfig) initHeaders() {
@@ -143,5 +146,15 @@ func WithBatchItemLimit(limit int) ClientOption {
 func WithBatchResponseSizeLimit(sizeLimit int) ClientOption {
 	return optionFunc(func(cfg *clientConfig) {
 		cfg.batchResponseLimit = sizeLimit
+	})
+}
+
+// WithWSAdmissionTimeout bounds how long incoming frames wait for concurrent-byte
+// budget before admission is rejected. Zero or negative values select the default (30s).
+//
+// Note: this option applies when processing incoming frames on persistent connections.
+func WithWSAdmissionTimeout(timeout time.Duration) ClientOption {
+	return optionFunc(func(cfg *clientConfig) {
+		cfg.wsAdmissionTimeout = timeout
 	})
 }

--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -69,7 +69,8 @@ type handler struct {
 	wsConcurrentBudget   *semaphore.Weighted
 	readLimit            int64
 	// admissionEventHook is called when WS byte-budget admission times out (see
-	// WSAdmissionReason*). Use it to emit metrics, logs, or other observability signals.
+	// WSAdmissionReason*). budget_wait_timeout = read loop stalled before the next
+	// read; frame_admission_timeout = decoded frame could not be admitted.
 	admissionEventHook func(reason string)
 	wsAdmissionTimeout   time.Duration
 
@@ -83,8 +84,13 @@ type callProc struct {
 }
 
 const (
-	WSAdmissionReasonPreDecodeTimeout  = "pre_decode_timeout"
-	WSAdmissionReasonPostDecodeTimeout = "post_decode_timeout"
+	// WSAdmissionReasonBudgetWaitTimeout is emitted when the read loop times out
+	// waiting for concurrent-byte budget before attempting the next read. No frame
+	// has been read yet; this signals backpressure, not frame rejection.
+	WSAdmissionReasonBudgetWaitTimeout = "budget_wait_timeout"
+	// WSAdmissionReasonFrameAdmissionTimeout is emitted when a decoded frame
+	// cannot be admitted under the concurrent-byte budget.
+	WSAdmissionReasonFrameAdmissionTimeout = "frame_admission_timeout"
 
 	defaultWSAdmissionTimeout = 30 * time.Second
 )
@@ -132,7 +138,7 @@ func (h *handler) acquirePreDecode(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, h.wsAdmissionTimeout)
 	defer cancel()
 	if err := h.wsConcurrentBudget.Acquire(ctx, h.readLimit); err != nil {
-		h.fireAdmissionEventOnBudgetTimeout(err, WSAdmissionReasonPreDecodeTimeout)
+		h.fireAdmissionEventOnBudgetTimeout(err, WSAdmissionReasonBudgetWaitTimeout)
 		return fmt.Errorf("concurrent request byte budget exhausted: %w", err)
 	}
 	return nil
@@ -166,7 +172,7 @@ func (h *handler) commitFrameBudget(ctx context.Context, rawLen int64) (release 
 		ctx, cancel := context.WithTimeout(ctx, h.wsAdmissionTimeout)
 		defer cancel()
 		if err := h.wsConcurrentBudget.Acquire(ctx, rawLen); err != nil {
-			h.fireAdmissionEventOnBudgetTimeout(err, WSAdmissionReasonPostDecodeTimeout)
+			h.fireAdmissionEventOnBudgetTimeout(err, WSAdmissionReasonFrameAdmissionTimeout)
 			return nil, fmt.Errorf("concurrent request byte budget exhausted: %w", err)
 		}
 		return func() { h.wsConcurrentBudget.Release(rawLen) }, nil
@@ -183,7 +189,7 @@ func (h *handler) commitFrameBudget(ctx context.Context, rawLen int64) (release 
 		ctx, cancel := context.WithTimeout(ctx, h.wsAdmissionTimeout)
 		defer cancel()
 		if err := h.wsConcurrentBudget.Acquire(ctx, weight-h.readLimit); err != nil {
-			h.fireAdmissionEventOnBudgetTimeout(err, WSAdmissionReasonPostDecodeTimeout)
+			h.fireAdmissionEventOnBudgetTimeout(err, WSAdmissionReasonFrameAdmissionTimeout)
 			return nil, fmt.Errorf("concurrent request byte budget exhausted: %w", err)
 		}
 	}

--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -68,6 +68,10 @@ type handler struct {
 	batchResponseMaxSize int
 	wsConcurrentBudget   *semaphore.Weighted
 	readLimit            int64
+	// admissionEventHook is called when WS byte-budget admission times out (see
+	// WSAdmissionReason*). Use it to emit metrics, logs, or other observability signals.
+	admissionEventHook func(reason string)
+	wsAdmissionTimeout   time.Duration
 
 	subLock    sync.Mutex
 	serverSubs map[ID]*Subscription
@@ -78,7 +82,21 @@ type callProc struct {
 	notifiers []*Notifier
 }
 
-func newHandler(connCtx context.Context, conn jsonWriter, idgen func() ID, reg *serviceRegistry, batchRequestLimit, batchResponseMaxSize int, wsConcurrentBudget *semaphore.Weighted, readLimit int64) *handler {
+const (
+	WSAdmissionReasonPreDecodeTimeout  = "pre_decode_timeout"
+	WSAdmissionReasonPostDecodeTimeout = "post_decode_timeout"
+
+	defaultWSAdmissionTimeout = 30 * time.Second
+)
+
+func wsAdmissionTimeoutOrDefault(timeout time.Duration) time.Duration {
+	if timeout > 0 {
+		return timeout
+	}
+	return defaultWSAdmissionTimeout
+}
+
+func newHandler(connCtx context.Context, conn jsonWriter, idgen func() ID, reg *serviceRegistry, batchRequestLimit, batchResponseMaxSize int, wsConcurrentBudget *semaphore.Weighted, readLimit int64, admissionEventHook func(reason string), wsAdmissionTimeout time.Duration) *handler {
 	rootCtx, cancelRoot := context.WithCancel(connCtx)
 	h := &handler{
 		reg:                  reg,
@@ -95,6 +113,8 @@ func newHandler(connCtx context.Context, conn jsonWriter, idgen func() ID, reg *
 		batchResponseMaxSize: batchResponseMaxSize,
 		wsConcurrentBudget:   wsConcurrentBudget,
 		readLimit:            readLimit,
+		admissionEventHook:   admissionEventHook,
+		wsAdmissionTimeout:   wsAdmissionTimeoutOrDefault(wsAdmissionTimeout),
 	}
 	if conn.remoteAddr() != "" {
 		h.log = h.log.New("conn", conn.remoteAddr())
@@ -103,22 +123,25 @@ func newHandler(connCtx context.Context, conn jsonWriter, idgen func() ID, reg *
 	return h
 }
 
-// wsAdmissionTimeout bounds how long a persistent connection will wait for
-// concurrent-byte budget to free up before a frame is read or committed.
-const wsAdmissionTimeout = 30 * time.Second
-
 // acquirePreDecode reserves frame budget before the codec reads/decodes the next
-// message. The wait is bounded by wsAdmissionTimeout.
+// message. The wait is bounded by the handler's wsAdmissionTimeout.
 func (h *handler) acquirePreDecode(ctx context.Context) error {
 	if h.wsConcurrentBudget == nil || h.readLimit <= 0 {
 		return nil
 	}
-	ctx, cancel := context.WithTimeout(ctx, wsAdmissionTimeout)
+	ctx, cancel := context.WithTimeout(ctx, h.wsAdmissionTimeout)
 	defer cancel()
 	if err := h.wsConcurrentBudget.Acquire(ctx, h.readLimit); err != nil {
+		h.fireAdmissionEventOnBudgetTimeout(err, WSAdmissionReasonPreDecodeTimeout)
 		return fmt.Errorf("concurrent request byte budget exhausted: %w", err)
 	}
 	return nil
+}
+
+func (h *handler) fireAdmissionEventOnBudgetTimeout(err error, reason string) {
+	if errors.Is(err, context.DeadlineExceeded) && h.admissionEventHook != nil {
+		h.admissionEventHook(reason)
+	}
 }
 
 // releasePreDecode releases a pre-decode reservation after a failed read/decode or a
@@ -140,9 +163,10 @@ func (h *handler) commitFrameBudget(ctx context.Context, rawLen int64) (release 
 		if rawLen <= 0 {
 			return func() {}, nil
 		}
-		ctx, cancel := context.WithTimeout(ctx, wsAdmissionTimeout)
+		ctx, cancel := context.WithTimeout(ctx, h.wsAdmissionTimeout)
 		defer cancel()
 		if err := h.wsConcurrentBudget.Acquire(ctx, rawLen); err != nil {
+			h.fireAdmissionEventOnBudgetTimeout(err, WSAdmissionReasonPostDecodeTimeout)
 			return nil, fmt.Errorf("concurrent request byte budget exhausted: %w", err)
 		}
 		return func() { h.wsConcurrentBudget.Release(rawLen) }, nil
@@ -156,9 +180,10 @@ func (h *handler) commitFrameBudget(ctx context.Context, rawLen int64) (release 
 	case weight < h.readLimit:
 		h.wsConcurrentBudget.Release(h.readLimit - weight)
 	case weight > h.readLimit:
-		ctx, cancel := context.WithTimeout(ctx, wsAdmissionTimeout)
+		ctx, cancel := context.WithTimeout(ctx, h.wsAdmissionTimeout)
 		defer cancel()
 		if err := h.wsConcurrentBudget.Acquire(ctx, weight-h.readLimit); err != nil {
+			h.fireAdmissionEventOnBudgetTimeout(err, WSAdmissionReasonPostDecodeTimeout)
 			return nil, fmt.Errorf("concurrent request byte budget exhausted: %w", err)
 		}
 	}

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -23,6 +23,7 @@ import (
 	"net"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/ethereum/go-ethereum/log"
 	"golang.org/x/sync/semaphore"
@@ -59,6 +60,8 @@ type Server struct {
 	readLimit                int64
 	wsConcurrentRequestBytes int64 // configured limit; 0 disables
 	wsConcurrentBudget       *semaphore.Weighted
+	admissionEventHook       func(reason string)
+	wsAdmissionTimeout       time.Duration
 }
 
 // NewServer creates a new server instance with no registered handlers.
@@ -113,6 +116,20 @@ func (s *Server) SetWSConcurrentRequestBytes(limit int64) {
 	s.recomputeWSConcurrentBudget()
 }
 
+// SetWSAdmissionEventHook registers a callback invoked when WS byte-budget admission
+// times out. Use the hook to emit metrics, logs, etc.
+func (s *Server) SetWSAdmissionEventHook(hook func(reason string)) {
+	s.admissionEventHook = hook
+}
+
+// SetWSAdmissionTimeout bounds how long a persistent connection will wait for
+// concurrent-byte budget to free up before a frame is read or committed. Zero or
+// negative values select the default (30s). This method should be called before
+// processing any requests via Websocket server.
+func (s *Server) SetWSAdmissionTimeout(timeout time.Duration) {
+	s.wsAdmissionTimeout = timeout
+}
+
 func (s *Server) recomputeWSConcurrentBudget() {
 	limit := s.wsConcurrentRequestBytes
 	if limit <= 0 {
@@ -158,6 +175,8 @@ func (s *Server) ServeCodec(codec ServerCodec, options CodecOption) {
 		batchResponseLimit: s.batchResponseLimit,
 		wsConcurrentBudget: s.wsConcurrentBudget,
 		readLimit:          s.readLimit,
+		admissionEventHook: s.admissionEventHook,
+		wsAdmissionTimeout: s.wsAdmissionTimeout,
 	}
 	c := initClient(codec, &s.services, cfg)
 	<-codec.closed()
@@ -191,7 +210,7 @@ func (s *Server) serveSingleRequest(ctx context.Context, codec ServerCodec) {
 		return
 	}
 
-	h := newHandler(ctx, codec, s.idgen, &s.services, s.batchItemLimit, s.batchResponseLimit, nil, s.readLimit)
+	h := newHandler(ctx, codec, s.idgen, &s.services, s.batchItemLimit, s.batchResponseLimit, nil, s.readLimit, nil, s.wsAdmissionTimeout)
 	h.allowSubscribe = false
 	defer h.close(io.EOF, nil)
 

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -117,7 +117,9 @@ func (s *Server) SetWSConcurrentRequestBytes(limit int64) {
 }
 
 // SetWSAdmissionEventHook registers a callback invoked when WS byte-budget admission
-// times out. Use the hook to emit metrics, logs, etc.
+// times out. reason is WSAdmissionReasonBudgetWaitTimeout when the read loop stalls
+// before the next read, or WSAdmissionReasonFrameAdmissionTimeout when a decoded
+// frame cannot be admitted.
 func (s *Server) SetWSAdmissionEventHook(hook func(reason string)) {
 	s.admissionEventHook = hook
 }

--- a/rpc/ws_admission_test.go
+++ b/rpc/ws_admission_test.go
@@ -252,7 +252,7 @@ func TestWSAdmissionTimeoutOrDefault(t *testing.T) {
 func TestFireAdmissionEventOnBudgetTimeout(t *testing.T) {
 	t.Parallel()
 
-	const reason = WSAdmissionReasonPreDecodeTimeout
+	const reason = WSAdmissionReasonBudgetWaitTimeout
 
 	t.Run("fires on deadline exceeded", func(t *testing.T) {
 		var got string
@@ -278,7 +278,7 @@ func TestFireAdmissionEventOnBudgetTimeout(t *testing.T) {
 	})
 }
 
-func TestAcquirePreDecodeFiresHookOnTimeout(t *testing.T) {
+func TestAcquirePreDecodeFiresBudgetWaitHookOnTimeout(t *testing.T) {
 	t.Parallel()
 
 	const (
@@ -305,15 +305,15 @@ func TestAcquirePreDecodeFiresHookOnTimeout(t *testing.T) {
 
 	select {
 	case reason := <-reasonCh:
-		if reason != WSAdmissionReasonPreDecodeTimeout {
-			t.Fatalf("hook reason = %q, want %q", reason, WSAdmissionReasonPreDecodeTimeout)
+		if reason != WSAdmissionReasonBudgetWaitTimeout {
+			t.Fatalf("hook reason = %q, want %q", reason, WSAdmissionReasonBudgetWaitTimeout)
 		}
 	case <-time.After(waitTimeout + 100*time.Millisecond):
-		t.Fatal("expected admission hook to fire on pre-decode timeout")
+		t.Fatal("expected admission hook to fire on budget wait timeout")
 	}
 }
 
-func TestCommitFrameBudgetFiresHookOnTimeout(t *testing.T) {
+func TestCommitFrameBudgetFiresFrameAdmissionHookOnTimeout(t *testing.T) {
 	t.Parallel()
 
 	const (
@@ -346,15 +346,15 @@ func TestCommitFrameBudgetFiresHookOnTimeout(t *testing.T) {
 
 	select {
 	case reason := <-reasonCh:
-		if reason != WSAdmissionReasonPostDecodeTimeout {
-			t.Fatalf("hook reason = %q, want %q", reason, WSAdmissionReasonPostDecodeTimeout)
+		if reason != WSAdmissionReasonFrameAdmissionTimeout {
+			t.Fatalf("hook reason = %q, want %q", reason, WSAdmissionReasonFrameAdmissionTimeout)
 		}
 	case <-time.After(waitTimeout + 100*time.Millisecond):
-		t.Fatal("expected admission hook to fire on post-decode timeout")
+		t.Fatal("expected admission hook to fire on frame admission timeout")
 	}
 }
 
-func TestServerWSAdmissionPreDecodeTimeoutFiresHook(t *testing.T) {
+func TestServerWSAdmissionBudgetWaitTimeoutFiresHook(t *testing.T) {
 	t.Parallel()
 
 	const (
@@ -410,8 +410,9 @@ func TestServerWSAdmissionPreDecodeTimeoutFiresHook(t *testing.T) {
 		}
 	}
 
-	// Request 1 holds the byte budget while it sleeps. The server then tries to
-	// admit the next frame and should time out before we send another request.
+	// Request 1 holds the byte budget while it sleeps. The read loop then waits
+	// for budget before the next read and should time out, even with no second
+	// request sent.
 	writeReq(1)
 
 	deadline := time.Now().Add(waitTimeout + 300*time.Millisecond)
@@ -420,13 +421,13 @@ func TestServerWSAdmissionPreDecodeTimeoutFiresHook(t *testing.T) {
 		got := append([]string(nil), reasons...)
 		mu.Unlock()
 		if len(got) > 0 {
-			if got[0] != WSAdmissionReasonPreDecodeTimeout {
-				t.Fatalf("hook reason = %q, want %q", got[0], WSAdmissionReasonPreDecodeTimeout)
+			if got[0] != WSAdmissionReasonBudgetWaitTimeout {
+				t.Fatalf("hook reason = %q, want %q", got[0], WSAdmissionReasonBudgetWaitTimeout)
 			}
 			return
 		}
 		if time.Now().After(deadline) {
-			t.Fatal("expected server admission hook to fire on pre-decode timeout")
+			t.Fatal("expected server admission hook to fire on budget wait timeout")
 		}
 		time.Sleep(10 * time.Millisecond)
 	}

--- a/rpc/ws_admission_test.go
+++ b/rpc/ws_admission_test.go
@@ -1,13 +1,17 @@
 package rpc
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net"
 	"strings"
+	"sync"
 	"testing"
 	"time"
+
+	"golang.org/x/sync/semaphore"
 )
 
 func TestWSConcurrentRequestBytesSingleInFlight(t *testing.T) {
@@ -201,4 +205,229 @@ func TestFrameBudgetExceededResponse(t *testing.T) {
 			t.Fatalf("expected null id when no call is present, got %s", batch[0].ID)
 		}
 	})
+}
+
+// stubJSONWriter satisfies jsonWriter for handler unit tests.
+type stubJSONWriter struct{}
+
+func (stubJSONWriter) writeJSON(context.Context, interface{}, bool) error { return nil }
+func (stubJSONWriter) closed() <-chan interface{}                         { return make(chan interface{}) }
+func (stubJSONWriter) remoteAddr() string                                 { return "" }
+
+func newAdmissionTestHandler(budget int64, readLimit int64, timeout time.Duration, hook func(string)) *handler {
+	return newHandler(
+		context.Background(),
+		stubJSONWriter{},
+		sequentialIDGenerator(),
+		new(serviceRegistry),
+		0, 0,
+		semaphore.NewWeighted(budget),
+		readLimit,
+		hook,
+		timeout,
+	)
+}
+
+func TestWSAdmissionTimeoutOrDefault(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		timeout time.Duration
+		want    time.Duration
+	}{
+		{name: "zero uses default", timeout: 0, want: defaultWSAdmissionTimeout},
+		{name: "negative uses default", timeout: -time.Second, want: defaultWSAdmissionTimeout},
+		{name: "positive is kept", timeout: 5 * time.Second, want: 5 * time.Second},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := wsAdmissionTimeoutOrDefault(tc.timeout); got != tc.want {
+				t.Fatalf("wsAdmissionTimeoutOrDefault(%v) = %v, want %v", tc.timeout, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFireAdmissionEventOnBudgetTimeout(t *testing.T) {
+	t.Parallel()
+
+	const reason = WSAdmissionReasonPreDecodeTimeout
+
+	t.Run("fires on deadline exceeded", func(t *testing.T) {
+		var got string
+		h := newAdmissionTestHandler(1, 1, time.Second, func(r string) { got = r })
+		h.fireAdmissionEventOnBudgetTimeout(context.DeadlineExceeded, reason)
+		if got != reason {
+			t.Fatalf("hook reason = %q, want %q", got, reason)
+		}
+	})
+
+	t.Run("does not fire on cancel", func(t *testing.T) {
+		var hookCalled bool
+		h := newAdmissionTestHandler(1, 1, time.Second, func(string) { hookCalled = true })
+		h.fireAdmissionEventOnBudgetTimeout(context.Canceled, reason)
+		if hookCalled {
+			t.Fatal("hook should not run for context.Canceled")
+		}
+	})
+
+	t.Run("does not fire without hook", func(t *testing.T) {
+		h := newAdmissionTestHandler(1, 1, time.Second, nil)
+		h.fireAdmissionEventOnBudgetTimeout(context.DeadlineExceeded, reason)
+	})
+}
+
+func TestAcquirePreDecodeFiresHookOnTimeout(t *testing.T) {
+	t.Parallel()
+
+	const (
+		frameBudget = int64(100)
+		readLimit   = int64(100)
+		waitTimeout = 20 * time.Millisecond
+	)
+
+	budget := semaphore.NewWeighted(frameBudget)
+	if err := budget.Acquire(t.Context(), frameBudget); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { budget.Release(frameBudget) })
+
+	reasonCh := make(chan string, 1)
+	h := newAdmissionTestHandler(frameBudget, readLimit, waitTimeout, func(reason string) {
+		reasonCh <- reason
+	})
+	h.wsConcurrentBudget = budget
+
+	if err := h.acquirePreDecode(t.Context()); err == nil {
+		t.Fatal("expected acquirePreDecode to fail when budget is exhausted")
+	}
+
+	select {
+	case reason := <-reasonCh:
+		if reason != WSAdmissionReasonPreDecodeTimeout {
+			t.Fatalf("hook reason = %q, want %q", reason, WSAdmissionReasonPreDecodeTimeout)
+		}
+	case <-time.After(waitTimeout + 100*time.Millisecond):
+		t.Fatal("expected admission hook to fire on pre-decode timeout")
+	}
+}
+
+func TestCommitFrameBudgetFiresHookOnTimeout(t *testing.T) {
+	t.Parallel()
+
+	const (
+		frameBudget = int64(100)
+		readLimit   = int64(50)
+		waitTimeout = 20 * time.Millisecond
+	)
+
+	budget := semaphore.NewWeighted(frameBudget)
+	reasonCh := make(chan string, 1)
+	h := newAdmissionTestHandler(frameBudget, readLimit, waitTimeout, func(reason string) {
+		reasonCh <- reason
+	})
+	h.wsConcurrentBudget = budget
+
+	if err := h.acquirePreDecode(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	if err := budget.Acquire(t.Context(), frameBudget-readLimit); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		h.releasePreDecode()
+		budget.Release(frameBudget - readLimit)
+	})
+
+	if _, err := h.commitFrameBudget(t.Context(), frameBudget); err == nil {
+		t.Fatal("expected commitFrameBudget to fail when extra budget is unavailable")
+	}
+
+	select {
+	case reason := <-reasonCh:
+		if reason != WSAdmissionReasonPostDecodeTimeout {
+			t.Fatalf("hook reason = %q, want %q", reason, WSAdmissionReasonPostDecodeTimeout)
+		}
+	case <-time.After(waitTimeout + 100*time.Millisecond):
+		t.Fatal("expected admission hook to fire on post-decode timeout")
+	}
+}
+
+func TestServerWSAdmissionPreDecodeTimeoutFiresHook(t *testing.T) {
+	t.Parallel()
+
+	const (
+		sleepDuration = 200 * time.Millisecond
+		pad           = 48
+		waitTimeout   = 50 * time.Millisecond
+	)
+
+	srv := newTestServer()
+
+	var (
+		mu      sync.Mutex
+		reasons []string
+	)
+	srv.SetWSAdmissionEventHook(func(reason string) {
+		mu.Lock()
+		reasons = append(reasons, reason)
+		mu.Unlock()
+	})
+	srv.SetWSAdmissionTimeout(waitTimeout)
+
+	p1, p2 := net.Pipe()
+	makeMsg := func(id int) string {
+		return fmt.Sprintf(
+			`{"jsonrpc":"2.0","id":%d,"method":"test_sleep","params":[%d],"_pad":"%s"}`,
+			id, sleepDuration.Nanoseconds(), strings.Repeat("x", pad),
+		)
+	}
+	payload := makeMsg(1)
+	frameSize := int64(len(payload))
+	srv.SetReadLimits(frameSize)
+	srv.SetWSConcurrentRequestBytes(frameSize)
+
+	serveDone := make(chan struct{})
+	go func() {
+		srv.ServeCodec(NewCodec(p1), 0)
+		close(serveDone)
+	}()
+	t.Cleanup(func() {
+		p2.Close()
+		p1.Close()
+		select {
+		case <-serveDone:
+		case <-time.After(2 * time.Second):
+			t.Error("ServeCodec did not exit within 2s")
+		}
+		srv.Stop()
+	})
+
+	writeReq := func(id int) {
+		if _, err := io.WriteString(p2, makeMsg(id)); err != nil {
+			t.Fatalf("write request %d: %v", id, err)
+		}
+	}
+
+	// Request 1 holds the byte budget while it sleeps. The server then tries to
+	// admit the next frame and should time out before we send another request.
+	writeReq(1)
+
+	deadline := time.Now().Add(waitTimeout + 300*time.Millisecond)
+	for {
+		mu.Lock()
+		got := append([]string(nil), reasons...)
+		mu.Unlock()
+		if len(got) > 0 {
+			if got[0] != WSAdmissionReasonPreDecodeTimeout {
+				t.Fatalf("hook reason = %q, want %q", got[0], WSAdmissionReasonPreDecodeTimeout)
+			}
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("expected server admission hook to fire on pre-decode timeout")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 }


### PR DESCRIPTION
## Summary
- Adds an `admissionEventHook func(reason string)` callback on `rpc.Server`/`rpc.Client`, invoked whenever WS concurrent-byte-budget admission times out (pre-decode or post-decode), so callers can emit metrics/logs on rejection instead of only surfacing an error.
- Makes the WS admission wait bound configurable via `Server.SetWSAdmissionTimeout` / `WithWSAdmissionTimeout`, replacing the previously hardcoded 30s constant (still the default when unset or non-positive).
- Introduces `WSAdmissionReasonPreDecodeTimeout` / `WSAdmissionReasonPostDecodeTimeout` constants passed to the hook so callers can distinguish where admission was rejected.

## Test plan
- [x] `go test ./rpc/...`
- New unit tests cover `wsAdmissionTimeoutOrDefault`, hook firing/non-firing on `acquirePreDecode`/`commitFrameBudget`, and an end-to-end server test asserting the hook fires with the correct reason on a real pre-decode timeout.