### PR TITLE
rpc: move pre-decode budget acquisition into the read loop, close WS admission-control gaps

### DIFF
--- a/rpc/client.go
+++ b/rpc/client.go
@@ -126,7 +126,17 @@ func (c *Client) newClientConn(conn ServerCodec) *clientConn {
 	ctx = context.WithValue(ctx, clientContextKey{}, c)
 	ctx = context.WithValue(ctx, peerInfoContextKey{}, conn.peerInfo())
 	handler := newHandler(ctx, conn, c.idgen, c.services, c.batchItemLimit, c.batchResponseMaxSize, c.wsConcurrentBudget, c.readLimit, c.admissionEventHook, c.wsAdmissionTimeout)
+	attachBudgetHandler(conn, handler)
 	return &clientConn{conn, handler}
+}
+
+func attachBudgetHandler(codec ServerCodec, h *handler) {
+	switch c := codec.(type) {
+	case *jsonCodec:
+		c.handler = h
+	case *websocketCodec:
+		c.handler = h
+	}
 }
 
 func (cc *clientConn) close(err error, inflightReq *requestOp) {
@@ -727,13 +737,8 @@ func (c *Client) read(conn *clientConn) {
 	codec := conn.codec
 	h := conn.handler
 	for {
-		if err := h.acquirePreDecode(h.rootCtx); err != nil {
-			c.readErr <- err
-			return
-		}
 		msgs, batch, rawLen, err := codec.readBatch()
 		if err != nil {
-			h.releasePreDecode()
 			var syntaxErr *json.SyntaxError
 			if errors.As(err, &syntaxErr) {
 				msg := errorMessage(&parseError{err.Error()})

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -742,6 +742,8 @@ func (c *Client) read(conn *clientConn) {
 	for {
 		msgs, batch, rawLen, err := codec.readBatch()
 		if err != nil {
+			// Unmatched errors (e.g. oversize WS frames) fall through with no
+			// response: gorilla already sent its own close(1009) for those.
 			var syntaxErr *json.SyntaxError
 			switch {
 			case errors.As(err, &syntaxErr):
@@ -750,9 +752,6 @@ func (c *Client) read(conn *clientConn) {
 			case errors.Is(err, errBudgetWaitTimeout):
 				msg := errorMessage(&internalServerError{errcodeBudgetWaitTimeout, errMsgBudgetWaitTimeout})
 				codec.writeJSON(context.Background(), msg, true)
-				// Oversize WS frames need no explicit response here: gorilla's own
-				// read-limit enforcement already sends a close(1009, "message too big")
-				// handshake to the peer before this error ever reaches the read loop.
 			}
 			c.readErr <- err
 			return

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -743,9 +743,16 @@ func (c *Client) read(conn *clientConn) {
 		msgs, batch, rawLen, err := codec.readBatch()
 		if err != nil {
 			var syntaxErr *json.SyntaxError
-			if errors.As(err, &syntaxErr) {
+			switch {
+			case errors.As(err, &syntaxErr):
 				msg := errorMessage(&parseError{err.Error()})
 				codec.writeJSON(context.Background(), msg, true)
+			case errors.Is(err, errBudgetWaitTimeout):
+				msg := errorMessage(&internalServerError{errcodeBudgetWaitTimeout, errMsgBudgetWaitTimeout})
+				codec.writeJSON(context.Background(), msg, true)
+				// Oversize WS frames need no explicit response here: gorilla's own
+				// read-limit enforcement already sends a close(1009, "message too big")
+				// handshake to the peer before this error ever reaches the read loop.
 			}
 			c.readErr <- err
 			return

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -130,12 +130,15 @@ func (c *Client) newClientConn(conn ServerCodec) *clientConn {
 	return &clientConn{conn, handler}
 }
 
+// budgetHandlerSetter is implemented by codecs that need the handler wired in for
+// byte-budget admission (jsonCodec and, via embedding, websocketCodec).
+type budgetHandlerSetter interface {
+	setBudgetHandler(h *handler)
+}
+
 func attachBudgetHandler(codec ServerCodec, h *handler) {
-	switch c := codec.(type) {
-	case *jsonCodec:
-		c.handler = h
-	case *websocketCodec:
-		c.handler = h
+	if c, ok := codec.(budgetHandlerSetter); ok {
+		c.setBudgetHandler(h)
 	}
 }
 

--- a/rpc/errors.go
+++ b/rpc/errors.go
@@ -24,7 +24,7 @@ import (
 // errBudgetWaitTimeout is a sentinel error that the handler wraps its pre-decode
 // budget-acquire error in, so the read loop can recognize an admission-control
 // rejection and report it to the peer before closing the connection.
-var errBudgetWaitTimeout = errors.New("timed out waiting for concurrent request-byte budget")
+var errBudgetWaitTimeout = errors.New(errMsgBudgetWaitTimeout)
 
 // HTTPError is returned by client operations when the HTTP status code of the
 // response is not a 2xx status.

--- a/rpc/errors.go
+++ b/rpc/errors.go
@@ -16,7 +16,15 @@
 
 package rpc
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
+
+// errBudgetWaitTimeout is a sentinel error that the handler wraps its pre-decode
+// budget-acquire error in, so the read loop can recognize an admission-control
+// rejection and report it to the peer before closing the connection.
+var errBudgetWaitTimeout = errors.New("timed out waiting for concurrent request-byte budget")
 
 // HTTPError is returned by client operations when the HTTP status code of the
 // response is not a 2xx status.
@@ -58,21 +66,23 @@ var (
 )
 
 const (
-	errcodeDefault          = -32000
-	errcodeTimeout          = -32002
-	errcodeResponseTooLarge = -32003
-	errcodeRequestTooLarge  = -32004
-	errcodePanic            = -32603
-	errcodeMarshalError     = -32603
+	errcodeDefault           = -32000
+	errcodeTimeout           = -32002
+	errcodeResponseTooLarge  = -32003
+	errcodeRequestTooLarge   = -32004
+	errcodeBudgetWaitTimeout = -32005
+	errcodePanic             = -32603
+	errcodeMarshalError      = -32603
 
 	legacyErrcodeNotificationsUnsupported = -32001
 )
 
 const (
-	errMsgTimeout          = "request timed out"
-	errMsgResponseTooLarge = "response too large"
-	errMsgBatchTooLarge    = "batch too large"
-	errMsgRequestTooLarge  = "request exceeds concurrent request-byte budget"
+	errMsgTimeout           = "request timed out"
+	errMsgResponseTooLarge  = "response too large"
+	errMsgBatchTooLarge     = "batch too large"
+	errMsgRequestTooLarge   = "request exceeds concurrent request-byte budget"
+	errMsgBudgetWaitTimeout = "timed out waiting for concurrent request-byte budget"
 )
 
 type methodNotFoundError struct{ method string }

--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -191,7 +191,6 @@ func (h *handler) commitFrameBudget(ctx context.Context, rawLen int64) (release 
 		return func() { h.wsConcurrentBudget.Release(rawLen) }, nil
 	}
 
-	h.preDecodeHeld = false
 	weight := rawLen
 	if weight <= 0 {
 		weight = h.readLimit
@@ -207,6 +206,7 @@ func (h *handler) commitFrameBudget(ctx context.Context, rawLen int64) (release 
 			return nil, fmt.Errorf("concurrent request byte budget exhausted: %w", err)
 		}
 	}
+	h.preDecodeHeld = false
 	return func() { h.wsConcurrentBudget.Release(weight) }, nil
 }
 

--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -91,6 +91,9 @@ const (
 	// WSAdmissionReasonFrameAdmissionTimeout is emitted when a decoded frame
 	// cannot be admitted under the concurrent-byte budget.
 	WSAdmissionReasonFrameAdmissionTimeout = "frame_admission_timeout"
+	// WSAdmissionReasonOversizeFrame is emitted when gorilla's read limit rejects
+	// an incoming frame before it is ever decoded (frame size > readLimit).
+	WSAdmissionReasonOversizeFrame = "oversize_frame"
 
 	defaultWSAdmissionTimeout = 30 * time.Second
 )

--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -142,7 +142,7 @@ func (h *handler) acquirePreDecode(ctx context.Context) error {
 	defer cancel()
 	if err := h.wsConcurrentBudget.Acquire(ctx, h.readLimit); err != nil {
 		h.fireAdmissionEventOnBudgetTimeout(err, WSAdmissionReasonBudgetWaitTimeout)
-		return fmt.Errorf("concurrent request byte budget exhausted: %w", err)
+		return fmt.Errorf("%w: %w", errBudgetWaitTimeout, err)
 	}
 	return nil
 }

--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -68,6 +68,9 @@ type handler struct {
 	batchResponseMaxSize int
 	wsConcurrentBudget   *semaphore.Weighted
 	readLimit            int64
+	// preDecodeHeld is true if acquirePreDecode reserved budget for the frame in
+	// flight. Single-goroutine access only (Client.read), so a plain bool is fine.
+	preDecodeHeld bool
 	// admissionEventHook is called when WS byte-budget admission times out (see
 	// WSAdmissionReason*). budget_wait_timeout = read loop stalled before the next
 	// read; frame_admission_timeout = decoded frame could not be admitted.
@@ -85,14 +88,13 @@ type callProc struct {
 
 const (
 	// WSAdmissionReasonBudgetWaitTimeout is emitted when the read loop times out
-	// waiting for concurrent-byte budget before attempting the next read. No frame
-	// has been read yet; this signals backpressure, not frame rejection.
+	// waiting for concurrent-byte budget before the next frame is decoded.
 	WSAdmissionReasonBudgetWaitTimeout = "budget_wait_timeout"
 	// WSAdmissionReasonFrameAdmissionTimeout is emitted when a decoded frame
 	// cannot be admitted under the concurrent-byte budget.
 	WSAdmissionReasonFrameAdmissionTimeout = "frame_admission_timeout"
 	// WSAdmissionReasonOversizeFrame is emitted when gorilla's read limit rejects
-	// an incoming frame before it is ever decoded (frame size > readLimit).
+	// an incoming message, on the first frame or partway through continuation frames.
 	WSAdmissionReasonOversizeFrame = "oversize_frame"
 
 	defaultWSAdmissionTimeout = 30 * time.Second
@@ -142,8 +144,13 @@ func (h *handler) acquirePreDecode(ctx context.Context) error {
 	defer cancel()
 	if err := h.wsConcurrentBudget.Acquire(ctx, h.readLimit); err != nil {
 		h.fireAdmissionEventOnBudgetTimeout(err, WSAdmissionReasonBudgetWaitTimeout)
-		return fmt.Errorf("%w: %w", errBudgetWaitTimeout, err)
+		if errors.Is(err, context.DeadlineExceeded) {
+			return fmt.Errorf("%w: %w", errBudgetWaitTimeout, err)
+		}
+		// Not a timeout (e.g. connection teardown) — don't report as one.
+		return fmt.Errorf("concurrent request byte budget: %w", err)
 	}
+	h.preDecodeHeld = true
 	return nil
 }
 
@@ -156,19 +163,22 @@ func (h *handler) fireAdmissionEventOnBudgetTimeout(err error, reason string) {
 // releasePreDecode releases a pre-decode reservation after a failed read/decode or a
 // failed commitFrameBudget call.
 func (h *handler) releasePreDecode() {
-	if h.wsConcurrentBudget == nil || h.readLimit <= 0 {
+	if !h.preDecodeHeld {
 		return
 	}
+	h.preDecodeHeld = false
 	h.wsConcurrentBudget.Release(h.readLimit)
 }
 
 // commitFrameBudget finalizes the reservation for a successfully decoded frame,
-// reconciling any pre-decode reservation against the frame's actual size.
+// reconciling any pre-decode reservation against the frame's actual size. If no
+// pre-decode reservation is held (readLimit unset, or the codec never wired in
+// this handler), it falls back to acquiring the full frame size directly.
 func (h *handler) commitFrameBudget(ctx context.Context, rawLen int64) (release func(), err error) {
 	if h.wsConcurrentBudget == nil {
 		return func() {}, nil
 	}
-	if h.readLimit <= 0 {
+	if h.readLimit <= 0 || !h.preDecodeHeld {
 		if rawLen <= 0 {
 			return func() {}, nil
 		}
@@ -181,6 +191,7 @@ func (h *handler) commitFrameBudget(ctx context.Context, rawLen int64) (release 
 		return func() { h.wsConcurrentBudget.Release(rawLen) }, nil
 	}
 
+	h.preDecodeHeld = false
 	weight := rawLen
 	if weight <= 0 {
 		weight = h.readLimit

--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -71,9 +71,9 @@ type handler struct {
 	// preDecodeHeld is true if acquirePreDecode reserved budget for the frame in
 	// flight. Single-goroutine access only (Client.read), so a plain bool is fine.
 	preDecodeHeld bool
-	// admissionEventHook is called when WS byte-budget admission times out (see
-	// WSAdmissionReason*). budget_wait_timeout = read loop stalled before the next
-	// read; frame_admission_timeout = decoded frame could not be admitted.
+	// admissionEventHook is called on WS admission-control events (see
+	// WSAdmissionReason*): budget_wait_timeout, frame_admission_timeout, or
+	// oversize_frame.
 	admissionEventHook func(reason string)
 	wsAdmissionTimeout   time.Duration
 

--- a/rpc/json.go
+++ b/rpc/json.go
@@ -185,7 +185,7 @@ type jsonCodec struct {
 	encMu   sync.Mutex       // guards the encoder
 	encode  encodeFunc       // encoder to allow multiple transports
 	conn    deadlineCloser
-	handler *handler // set by the read loop for byte-budget admission on IPC
+	handler *handler // set by the read loop for byte-budget admission
 }
 
 type encodeFunc = func(v interface{}, isErrorResponse bool) error
@@ -221,9 +221,7 @@ func NewCodec(conn Conn) ServerCodec {
 	return NewFuncCodec(conn, encode, dec.Decode)
 }
 
-// setBudgetHandler wires in the handler used for byte-budget admission. It is called
-// once, before the read loop starts, by websocketCodec (via embedding) and jsonCodec
-// itself (for IPC).
+// setBudgetHandler wires in the handler used for byte-budget admission.
 func (c *jsonCodec) setBudgetHandler(h *handler) {
 	c.handler = h
 }

--- a/rpc/json.go
+++ b/rpc/json.go
@@ -185,6 +185,7 @@ type jsonCodec struct {
 	encMu   sync.Mutex       // guards the encoder
 	encode  encodeFunc       // encoder to allow multiple transports
 	conn    deadlineCloser
+	handler *handler // set by the read loop for byte-budget admission on IPC
 }
 
 type encodeFunc = func(v interface{}, isErrorResponse bool) error
@@ -230,10 +231,18 @@ func (c *jsonCodec) remoteAddr() string {
 }
 
 func (c *jsonCodec) readBatch() (messages []*jsonrpcMessage, batch bool, rawLen int64, err error) {
+	if c.handler != nil {
+		if err = c.handler.acquirePreDecode(c.handler.rootCtx); err != nil {
+			return nil, false, 0, err
+		}
+	}
 	// Decode the next JSON object in the input stream.
 	// This verifies basic syntax, etc.
 	var rawmsg json.RawMessage
-	if err := c.decode(&rawmsg); err != nil {
+	if err = c.decode(&rawmsg); err != nil {
+		if c.handler != nil {
+			c.handler.releasePreDecode()
+		}
 		return nil, false, 0, err
 	}
 	messages, batch = parseMessage(rawmsg)

--- a/rpc/json.go
+++ b/rpc/json.go
@@ -221,6 +221,13 @@ func NewCodec(conn Conn) ServerCodec {
 	return NewFuncCodec(conn, encode, dec.Decode)
 }
 
+// setBudgetHandler wires in the handler used for byte-budget admission. It is called
+// once, before the read loop starts, by websocketCodec (via embedding) and jsonCodec
+// itself (for IPC).
+func (c *jsonCodec) setBudgetHandler(h *handler) {
+	c.handler = h
+}
+
 func (c *jsonCodec) peerInfo() PeerInfo {
 	// This returns "ipc" because all other built-in transports have a separate codec type.
 	return PeerInfo{Transport: "ipc", RemoteAddr: c.remote}

--- a/rpc/json.go
+++ b/rpc/json.go
@@ -236,6 +236,8 @@ func (c *jsonCodec) remoteAddr() string {
 }
 
 func (c *jsonCodec) readBatch() (messages []*jsonrpcMessage, batch bool, rawLen int64, err error) {
+	// Unlike websocketCodec, this reserves budget before the blocking read for the
+	// next message, so an idle IPC/stdio connection still holds it indefinitely.
 	if c.handler != nil {
 		if err = c.handler.acquirePreDecode(c.handler.rootCtx); err != nil {
 			return nil, false, 0, err

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -111,6 +111,9 @@ func (s *Server) SetReadLimits(limit int64) {
 // frames on persistent connections (WebSocket, IPC, stdio) that may be read and
 // processed concurrently, weighted by each frame's size. Set to 0 to disable the limit.
 // This method should be called before processing any requests via Websocket server.
+//
+// Note: idle connections avoid holding this budget on WebSocket only; idle
+// IPC/stdio connections still hold readLimit bytes indefinitely.
 func (s *Server) SetWSConcurrentRequestBytes(limit int64) {
 	s.wsConcurrentRequestBytes = limit
 	s.recomputeWSConcurrentBudget()

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -119,18 +119,24 @@ func (s *Server) SetWSConcurrentRequestBytes(limit int64) {
 	s.recomputeWSConcurrentBudget()
 }
 
-// SetWSAdmissionEventHook registers a callback invoked when WS byte-budget admission
-// times out. reason is WSAdmissionReasonBudgetWaitTimeout when the read loop stalls
-// before the next read, or WSAdmissionReasonFrameAdmissionTimeout when a decoded
-// frame cannot be admitted.
+// SetWSAdmissionEventHook registers a callback invoked on WS admission-control
+// events. reason is one of:
+//   - WSAdmissionReasonBudgetWaitTimeout when the read loop stalls waiting for
+//     concurrent-byte budget before the next frame is decoded;
+//   - WSAdmissionReasonFrameAdmissionTimeout when a decoded frame cannot be
+//     admitted under the concurrent-byte budget;
+//   - WSAdmissionReasonOversizeFrame when gorilla's read limit rejects an
+//     incoming message before or during decode.
 func (s *Server) SetWSAdmissionEventHook(hook func(reason string)) {
 	s.admissionEventHook = hook
 }
 
 // SetWSAdmissionTimeout bounds how long a persistent connection will wait for
-// concurrent-byte budget to free up before a frame is read or committed. Zero or
-// negative values select the default (30s). This method should be called before
-// processing any requests via Websocket server.
+// concurrent-byte budget to free up before a frame is read or committed, and how
+// long a WebSocket frame may take to finish arriving after its first data frame
+// once budget has been reserved for it. Zero or negative values select the
+// default (30s). This method should be called before processing any requests
+// via Websocket server.
 func (s *Server) SetWSAdmissionTimeout(timeout time.Duration) {
 	s.wsAdmissionTimeout = timeout
 }

--- a/rpc/websocket.go
+++ b/rpc/websocket.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -327,6 +328,9 @@ func newWebsocketCodec(conn *websocket.Conn, host string, req http.Header, readL
 func (wc *websocketCodec) readBatch() ([]*jsonrpcMessage, bool, int64, error) {
 	_, r, err := wc.conn.NextReader()
 	if err != nil {
+		if errors.Is(err, websocket.ErrReadLimit) && wc.handler != nil && wc.handler.admissionEventHook != nil {
+			wc.handler.admissionEventHook(WSAdmissionReasonOversizeFrame)
+		}
 		return nil, false, 0, err
 	}
 	if wc.handler != nil {

--- a/rpc/websocket.go
+++ b/rpc/websocket.go
@@ -356,6 +356,9 @@ func (wc *websocketCodec) readBatch() ([]*jsonrpcMessage, bool, int64, error) {
 	return messages, batch, int64(len(rawmsg)), nil
 }
 
+// fireOversizeFrameHook reports a frame rejected by gorilla's read-limit enforcement
+// to the admission event hook. No JSON-RPC response is written for this case: gorilla
+// already sends a close(1009, "message too big") handshake to the peer on its own.
 func (wc *websocketCodec) fireOversizeFrameHook(err error) {
 	if errors.Is(err, websocket.ErrReadLimit) && wc.handler != nil && wc.handler.admissionEventHook != nil {
 		wc.handler.admissionEventHook(WSAdmissionReasonOversizeFrame)

--- a/rpc/websocket.go
+++ b/rpc/websocket.go
@@ -19,6 +19,7 @@ package rpc
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -283,8 +284,9 @@ func wsClientHeaders(endpoint, origin string) (string, http.Header, error) {
 
 type websocketCodec struct {
 	*jsonCodec
-	conn *websocket.Conn
-	info PeerInfo
+	conn    *websocket.Conn
+	handler *handler // set by the read loop for byte-budget admission
+	info    PeerInfo
 
 	wg           sync.WaitGroup
 	pingReset    chan struct{}
@@ -321,6 +323,32 @@ func newWebsocketCodec(conn *websocket.Conn, host string, req http.Header, readL
 	wc.wg.Add(1)
 	go wc.pingLoop()
 	return wc
+}
+
+func (wc *websocketCodec) readBatch() ([]*jsonrpcMessage, bool, int64, error) {
+	_, r, err := wc.conn.NextReader()
+	if err != nil {
+		return nil, false, 0, err
+	}
+	if wc.handler != nil {
+		if err := wc.handler.acquirePreDecode(wc.handler.rootCtx); err != nil {
+			return nil, false, 0, err
+		}
+	}
+	var rawmsg json.RawMessage
+	if err := json.NewDecoder(r).Decode(&rawmsg); err != nil {
+		if wc.handler != nil {
+			wc.handler.releasePreDecode()
+		}
+		return nil, false, 0, err
+	}
+	messages, batch := parseMessage(rawmsg)
+	for i, msg := range messages {
+		if msg == nil {
+			messages[i] = new(jsonrpcMessage)
+		}
+	}
+	return messages, batch, int64(len(rawmsg)), nil
 }
 
 func (wc *websocketCodec) close() {

--- a/rpc/websocket.go
+++ b/rpc/websocket.go
@@ -292,6 +292,12 @@ type websocketCodec struct {
 	wg           sync.WaitGroup
 	pingReset    chan struct{}
 	pongReceived chan struct{}
+
+	// decodeReadActive is true while a frame is being decoded after pre-decode budget
+	// has been reserved. It is guarded by jsonCodec.encMu, the same lock pingLoop
+	// already holds around its own SetReadDeadline calls, so pingLoop's pong-triggered
+	// deadline clear can never race past a decode-owned deadline.
+	decodeReadActive bool
 }
 
 func newWebsocketCodec(conn *websocket.Conn, host string, req http.Header, readLimit int64) ServerCodec {
@@ -336,6 +342,10 @@ func (wc *websocketCodec) readBatch() ([]*jsonrpcMessage, bool, int64, error) {
 		if err := wc.handler.acquirePreDecode(wc.handler.rootCtx); err != nil {
 			return nil, false, 0, err
 		}
+		if wc.handler.preDecodeHeld {
+			wc.beginDecodeRead(wc.handler.wsAdmissionTimeout)
+			defer wc.endDecodeRead()
+		}
 	}
 	var rawmsg json.RawMessage
 	if err := json.NewDecoder(r).Decode(&rawmsg); err != nil {
@@ -359,6 +369,32 @@ func (wc *websocketCodec) readBatch() ([]*jsonrpcMessage, bool, int64, error) {
 		}
 	}
 	return messages, batch, int64(len(rawmsg)), nil
+}
+
+// beginDecodeRead arms a read deadline bounding how long a frame may take to finish
+// arriving once pre-decode budget has been reserved for it, so a peer that stalls
+// mid-message (and keeps ponging to defeat pingLoop's own liveness deadline) cannot
+// hold that budget indefinitely.
+func (wc *websocketCodec) beginDecodeRead(timeout time.Duration) {
+	if timeout <= 0 {
+		return
+	}
+	wc.jsonCodec.encMu.Lock()
+	defer wc.jsonCodec.encMu.Unlock()
+	wc.decodeReadActive = true
+	wc.conn.SetReadDeadline(time.Now().Add(timeout))
+}
+
+// endDecodeRead clears the deadline armed by beginDecodeRead once the frame has been
+// fully read (successfully or not).
+func (wc *websocketCodec) endDecodeRead() {
+	wc.jsonCodec.encMu.Lock()
+	defer wc.jsonCodec.encMu.Unlock()
+	if !wc.decodeReadActive {
+		return
+	}
+	wc.decodeReadActive = false
+	wc.conn.SetReadDeadline(time.Time{})
 }
 
 // fireOversizeFrameHook reports a frame rejected by gorilla's read-limit enforcement
@@ -412,12 +448,21 @@ func (wc *websocketCodec) pingLoop() {
 			wc.jsonCodec.encMu.Lock()
 			wc.conn.SetWriteDeadline(time.Now().Add(wsPingWriteTimeout))
 			wc.conn.WriteMessage(websocket.PingMessage, nil)
-			wc.conn.SetReadDeadline(time.Now().Add(wsPongTimeout))
+			// A frame being decoded already owns the read deadline; don't override it
+			// with the longer pong-liveness deadline, or a stalling peer that keeps
+			// ponging could ride out the decode bound indefinitely.
+			if !wc.decodeReadActive {
+				wc.conn.SetReadDeadline(time.Now().Add(wsPongTimeout))
+			}
 			wc.jsonCodec.encMu.Unlock()
 			pingTimer.Reset(wsPingInterval)
 
 		case <-wc.pongReceived:
-			wc.conn.SetReadDeadline(time.Time{})
+			wc.jsonCodec.encMu.Lock()
+			if !wc.decodeReadActive {
+				wc.conn.SetReadDeadline(time.Time{})
+			}
+			wc.jsonCodec.encMu.Unlock()
 		}
 	}
 }

--- a/rpc/websocket.go
+++ b/rpc/websocket.go
@@ -283,10 +283,9 @@ func wsClientHeaders(endpoint, origin string) (string, http.Header, error) {
 }
 
 type websocketCodec struct {
-	*jsonCodec
-	conn    *websocket.Conn
-	handler *handler // set by the read loop for byte-budget admission
-	info    PeerInfo
+	*jsonCodec // also carries the handler set by the read loop for byte-budget admission
+	conn       *websocket.Conn
+	info       PeerInfo
 
 	wg           sync.WaitGroup
 	pingReset    chan struct{}

--- a/rpc/websocket.go
+++ b/rpc/websocket.go
@@ -328,9 +328,7 @@ func newWebsocketCodec(conn *websocket.Conn, host string, req http.Header, readL
 func (wc *websocketCodec) readBatch() ([]*jsonrpcMessage, bool, int64, error) {
 	_, r, err := wc.conn.NextReader()
 	if err != nil {
-		if errors.Is(err, websocket.ErrReadLimit) && wc.handler != nil && wc.handler.admissionEventHook != nil {
-			wc.handler.admissionEventHook(WSAdmissionReasonOversizeFrame)
-		}
+		wc.fireOversizeFrameHook(err)
 		return nil, false, 0, err
 	}
 	if wc.handler != nil {
@@ -343,6 +341,10 @@ func (wc *websocketCodec) readBatch() ([]*jsonrpcMessage, bool, int64, error) {
 		if wc.handler != nil {
 			wc.handler.releasePreDecode()
 		}
+		// A message split across continuation frames only crosses gorilla's read
+		// limit once enough frames have arrived, so ErrReadLimit can surface here
+		// instead of from NextReader above.
+		wc.fireOversizeFrameHook(err)
 		return nil, false, 0, err
 	}
 	messages, batch := parseMessage(rawmsg)
@@ -352,6 +354,12 @@ func (wc *websocketCodec) readBatch() ([]*jsonrpcMessage, bool, int64, error) {
 		}
 	}
 	return messages, batch, int64(len(rawmsg)), nil
+}
+
+func (wc *websocketCodec) fireOversizeFrameHook(err error) {
+	if errors.Is(err, websocket.ErrReadLimit) && wc.handler != nil && wc.handler.admissionEventHook != nil {
+		wc.handler.admissionEventHook(WSAdmissionReasonOversizeFrame)
+	}
 }
 
 func (wc *websocketCodec) close() {

--- a/rpc/websocket.go
+++ b/rpc/websocket.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -340,6 +341,10 @@ func (wc *websocketCodec) readBatch() ([]*jsonrpcMessage, bool, int64, error) {
 	if err := json.NewDecoder(r).Decode(&rawmsg); err != nil {
 		if wc.handler != nil {
 			wc.handler.releasePreDecode()
+		}
+		// Match gorilla's ReadJSON: don't let an empty frame look like a clean EOF.
+		if err == io.EOF {
+			err = io.ErrUnexpectedEOF
 		}
 		// A message split across continuation frames only crosses gorilla's read
 		// limit once enough frames have arrived, so ErrReadLimit can surface here

--- a/rpc/websocket.go
+++ b/rpc/websocket.go
@@ -284,9 +284,9 @@ func wsClientHeaders(endpoint, origin string) (string, http.Header, error) {
 }
 
 type websocketCodec struct {
-	*jsonCodec // also carries the handler set by the read loop for byte-budget admission
-	conn       *websocket.Conn
-	info       PeerInfo
+	*jsonCodec
+	conn *websocket.Conn
+	info PeerInfo
 
 	wg           sync.WaitGroup
 	pingReset    chan struct{}

--- a/rpc/ws_admission_test.go
+++ b/rpc/ws_admission_test.go
@@ -259,6 +259,77 @@ func TestWSOversizeFrameFiresAdmissionHook(t *testing.T) {
 	}
 }
 
+// TestWSFragmentedOversizeFrameFiresAdmissionHook covers a message that only crosses
+// gorilla's read limit partway through a run of continuation frames.
+func TestWSFragmentedOversizeFrameFiresAdmissionHook(t *testing.T) {
+	t.Parallel()
+
+	const (
+		readLimit = 200
+		budget    = 1024
+		padLen    = 2000
+	)
+
+	var (
+		mu      sync.Mutex
+		reasons []string
+	)
+	srv := newTestServer()
+	srv.SetWSAdmissionEventHook(func(reason string) {
+		mu.Lock()
+		reasons = append(reasons, reason)
+		mu.Unlock()
+	})
+	srv.SetReadLimits(readLimit)
+	srv.SetWSConcurrentRequestBytes(budget)
+	_, wsURL := startWSTestServer(t, srv)
+
+	// A small write buffer forces gorilla to split a single large Write into many
+	// continuation frames, each well under readLimit on its own.
+	dialer := &websocket.Dialer{WriteBufferSize: 16}
+	conn, _, err := dialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	t.Cleanup(func() { conn.Close() })
+
+	w, err := conn.NextWriter(websocket.TextMessage)
+	if err != nil {
+		t.Fatalf("next writer: %v", err)
+	}
+	oversized := fmt.Sprintf(
+		`{"jsonrpc":"2.0","id":1,"method":"test_echo","params":["%s"]}`,
+		strings.Repeat("x", padLen),
+	)
+	// The server closes the connection as soon as it detects the read-limit
+	// violation, which can happen before the client finishes writing every
+	// continuation frame — so a write/close error here is expected, not fatal.
+	_, _ = w.Write([]byte(oversized))
+	_ = w.Close()
+
+	conn.SetReadDeadline(time.Now().Add(time.Second))
+	if _, _, err := conn.ReadMessage(); err == nil {
+		t.Fatal("expected connection to close after oversized fragmented message")
+	}
+
+	deadline := time.Now().Add(time.Second)
+	for {
+		mu.Lock()
+		got := append([]string(nil), reasons...)
+		mu.Unlock()
+		if len(got) > 0 {
+			if len(got) != 1 || got[0] != WSAdmissionReasonOversizeFrame {
+				t.Fatalf("admission hook reasons = %v, want [%q]", got, WSAdmissionReasonOversizeFrame)
+			}
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("expected oversize-frame admission hook to fire for a fragmented message")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
 func TestWSConcurrentLargeFrames(t *testing.T) {
 	t.Parallel()
 

--- a/rpc/ws_admission_test.go
+++ b/rpc/ws_admission_test.go
@@ -161,7 +161,6 @@ func TestWSBudgetAcquiredOnlyOnFrame(t *testing.T) {
 	_, wsURL := startWSTestServer(t, srv)
 
 	conn := dialWS(t, wsURL)
-	t.Cleanup(func() { conn.Close() })
 	writeWSJSON(t, conn, payload)
 
 	held := false
@@ -272,7 +271,6 @@ func TestWSLargeFrameRejectedByReadLimit(t *testing.T) {
 	_, wsURL := startWSTestServer(t, srv)
 
 	conn := dialWS(t, wsURL)
-	t.Cleanup(func() { conn.Close() })
 	oversized := fmt.Sprintf(
 		`{"jsonrpc":"2.0","id":1,"method":"test_echo","params":["%s"]}`,
 		strings.Repeat("x", readLimit),
@@ -313,7 +311,6 @@ func TestWSOversizeFrameFiresAdmissionHook(t *testing.T) {
 	_, wsURL := startWSTestServer(t, srv)
 
 	conn := dialWS(t, wsURL)
-	t.Cleanup(func() { conn.Close() })
 	oversized := fmt.Sprintf(
 		`{"jsonrpc":"2.0","id":1,"method":"test_echo","params":["%s"]}`,
 		strings.Repeat("x", readLimit),

--- a/rpc/ws_admission_test.go
+++ b/rpc/ws_admission_test.go
@@ -217,6 +217,48 @@ func TestWSLargeFrameRejectedByReadLimit(t *testing.T) {
 	srv.wsConcurrentBudget.Release(budget)
 }
 
+func TestWSOversizeFrameFiresAdmissionHook(t *testing.T) {
+	t.Parallel()
+
+	const (
+		readLimit = 256
+		budget    = 1024
+	)
+
+	var (
+		mu      sync.Mutex
+		reasons []string
+	)
+	srv := newTestServer()
+	srv.SetWSAdmissionEventHook(func(reason string) {
+		mu.Lock()
+		reasons = append(reasons, reason)
+		mu.Unlock()
+	})
+	srv.SetReadLimits(readLimit)
+	srv.SetWSConcurrentRequestBytes(budget)
+	_, wsURL := startWSTestServer(t, srv)
+
+	conn := dialWS(t, wsURL)
+	oversized := fmt.Sprintf(
+		`{"jsonrpc":"2.0","id":1,"method":"test_echo","params":["%s"]}`,
+		strings.Repeat("x", readLimit),
+	)
+	writeWSJSON(t, conn, oversized)
+
+	conn.SetReadDeadline(time.Now().Add(time.Second))
+	if _, _, err := conn.ReadMessage(); err == nil {
+		t.Fatal("expected connection to close after oversized frame")
+	}
+
+	mu.Lock()
+	got := append([]string(nil), reasons...)
+	mu.Unlock()
+	if len(got) != 1 || got[0] != WSAdmissionReasonOversizeFrame {
+		t.Fatalf("admission hook reasons = %v, want [%q]", got, WSAdmissionReasonOversizeFrame)
+	}
+}
+
 func TestWSConcurrentLargeFrames(t *testing.T) {
 	t.Parallel()
 

--- a/rpc/ws_admission_test.go
+++ b/rpc/ws_admission_test.go
@@ -161,6 +161,7 @@ func TestWSBudgetAcquiredOnlyOnFrame(t *testing.T) {
 	_, wsURL := startWSTestServer(t, srv)
 
 	conn := dialWS(t, wsURL)
+	t.Cleanup(func() { conn.Close() })
 	writeWSJSON(t, conn, payload)
 
 	held := false
@@ -271,6 +272,7 @@ func TestWSLargeFrameRejectedByReadLimit(t *testing.T) {
 	_, wsURL := startWSTestServer(t, srv)
 
 	conn := dialWS(t, wsURL)
+	t.Cleanup(func() { conn.Close() })
 	oversized := fmt.Sprintf(
 		`{"jsonrpc":"2.0","id":1,"method":"test_echo","params":["%s"]}`,
 		strings.Repeat("x", readLimit),
@@ -311,6 +313,7 @@ func TestWSOversizeFrameFiresAdmissionHook(t *testing.T) {
 	_, wsURL := startWSTestServer(t, srv)
 
 	conn := dialWS(t, wsURL)
+	t.Cleanup(func() { conn.Close() })
 	oversized := fmt.Sprintf(
 		`{"jsonrpc":"2.0","id":1,"method":"test_echo","params":["%s"]}`,
 		strings.Repeat("x", readLimit),

--- a/rpc/ws_admission_test.go
+++ b/rpc/ws_admission_test.go
@@ -72,7 +72,7 @@ func TestWSIdleConnectionsDoNotHoldBudget(t *testing.T) {
 	const (
 		frameSize = 500
 		budget    = 1000
-		idleConns = 50
+		idleConns = 15
 	)
 
 	srv := newTestServer()
@@ -90,12 +90,17 @@ func TestWSIdleConnectionsDoNotHoldBudget(t *testing.T) {
 		}
 	})
 
-	time.Sleep(100 * time.Millisecond)
-
-	if !srv.wsConcurrentBudget.TryAcquire(budget) {
-		t.Fatal("idle websocket connections should not hold byte budget")
+	deadline := time.Now().Add(time.Second)
+	for {
+		if srv.wsConcurrentBudget.TryAcquire(budget) {
+			srv.wsConcurrentBudget.Release(budget)
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("idle websocket connections should not hold byte budget")
+		}
+		time.Sleep(5 * time.Millisecond)
 	}
-	srv.wsConcurrentBudget.Release(budget)
 }
 
 func TestWSManyIdleSubscriptions(t *testing.T) {
@@ -104,7 +109,7 @@ func TestWSManyIdleSubscriptions(t *testing.T) {
 	const (
 		frameSize = 500
 		budget    = 1000
-		numConns  = 100
+		numConns  = 20
 	)
 
 	srv := newTestServer()
@@ -130,8 +135,7 @@ func TestWSManyIdleSubscriptions(t *testing.T) {
 		}
 	})
 
-	time.Sleep(100 * time.Millisecond)
-
+	// No settling delay needed: each subscribe ack was already read above.
 	extra := dialWS(t, wsURL)
 	writeWSJSON(t, extra, makeSleepMsg(99, 10*time.Millisecond, 48))
 	var resp jsonrpcMessage
@@ -251,11 +255,22 @@ func TestWSOversizeFrameFiresAdmissionHook(t *testing.T) {
 		t.Fatal("expected connection to close after oversized frame")
 	}
 
-	mu.Lock()
-	got := append([]string(nil), reasons...)
-	mu.Unlock()
-	if len(got) != 1 || got[0] != WSAdmissionReasonOversizeFrame {
-		t.Fatalf("admission hook reasons = %v, want [%q]", got, WSAdmissionReasonOversizeFrame)
+	// Poll: gorilla's close(1009) can reach the client before the hook fires.
+	deadline := time.Now().Add(time.Second)
+	for {
+		mu.Lock()
+		got := append([]string(nil), reasons...)
+		mu.Unlock()
+		if len(got) > 0 {
+			if len(got) != 1 || got[0] != WSAdmissionReasonOversizeFrame {
+				t.Fatalf("admission hook reasons = %v, want [%q]", got, WSAdmissionReasonOversizeFrame)
+			}
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("expected oversize-frame admission hook to fire")
+		}
+		time.Sleep(5 * time.Millisecond)
 	}
 }
 
@@ -403,12 +418,75 @@ func TestWSBudgetWaitTimeoutOnActiveBurst(t *testing.T) {
 			if got[0] != WSAdmissionReasonBudgetWaitTimeout {
 				t.Fatalf("hook reason = %q, want %q", got[0], WSAdmissionReasonBudgetWaitTimeout)
 			}
-			return
+			break
 		}
 		if time.Now().After(deadline) {
 			t.Fatal("expected admission hook to fire when a second frame waits on budget")
 		}
 		time.Sleep(10 * time.Millisecond)
+	}
+
+	// Confirm the peer actually receives the -32005 error, not just the hook firing.
+	conn.SetReadDeadline(time.Now().Add(waitTimeout + 2*sleepDuration))
+	foundBudgetTimeoutResp := false
+	for {
+		_, data, err := conn.ReadMessage()
+		if err != nil {
+			break
+		}
+		var resp jsonrpcMessage
+		if err := json.Unmarshal(data, &resp); err != nil {
+			continue
+		}
+		if resp.Error != nil && resp.Error.Code == errcodeBudgetWaitTimeout {
+			foundBudgetTimeoutResp = true
+			break
+		}
+	}
+	if !foundBudgetTimeoutResp {
+		t.Fatalf("expected peer to receive a JSON-RPC error with code %d before the connection closed", errcodeBudgetWaitTimeout)
+	}
+}
+
+// passthroughCodec embeds ServerCodec without implementing budgetHandlerSetter, so
+// attachBudgetHandler's type assertion fails for it — like any decorator that forwards
+// reads but not setBudgetHandler.
+type passthroughCodec struct {
+	ServerCodec
+}
+
+// TestBudgetCommitWithoutHandlerWiringDoesNotPanic guards against a regression where
+// commitFrameBudget released budget that was never acquired for an unwired codec,
+// panicking the semaphore on the first request.
+func TestBudgetCommitWithoutHandlerWiringDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	const (
+		readLimit = 256
+		budget    = 1024
+	)
+
+	srv := newTestServer()
+	srv.SetReadLimits(readLimit)
+	srv.SetWSConcurrentRequestBytes(budget)
+
+	p1, p2 := net.Pipe()
+	wrapped := &passthroughCodec{ServerCodec: NewCodec(p1)}
+	go srv.ServeCodec(wrapped, 0)
+	t.Cleanup(func() { p2.Close(); p1.Close(); srv.Stop() })
+
+	payload := `{"jsonrpc":"2.0","id":1,"method":"test_echo","params":["hello",1,{"S":"world"}]}`
+	if _, err := io.WriteString(p2, payload); err != nil {
+		t.Fatal(err)
+	}
+	dec := json.NewDecoder(p2)
+	_ = p2.SetReadDeadline(time.Now().Add(time.Second))
+	var resp jsonrpcMessage
+	if err := dec.Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %v", resp.Error)
 	}
 }
 

--- a/rpc/ws_admission_test.go
+++ b/rpc/ws_admission_test.go
@@ -190,6 +190,73 @@ func TestWSBudgetAcquiredOnlyOnFrame(t *testing.T) {
 	srv.wsConcurrentBudget.Release(frameSize)
 }
 
+// TestWSPartialFrameStallReleasesBudget verifies that a peer which sends only the
+// first fragment of a message and then stalls cannot hold pre-decode budget
+// indefinitely: once wsAdmissionTimeout elapses since the first frame arrived, the
+// server must abandon the read and release the reservation, even though the
+// connection is otherwise alive.
+func TestWSPartialFrameStallReleasesBudget(t *testing.T) {
+	t.Parallel()
+
+	const (
+		waitTimeout = 50 * time.Millisecond
+		readLimit   = 256
+		budget      = 256
+	)
+
+	srv := newTestServer()
+	srv.SetWSAdmissionTimeout(waitTimeout)
+	srv.SetReadLimits(readLimit)
+	srv.SetWSConcurrentRequestBytes(budget)
+	_, wsURL := startWSTestServer(t, srv)
+
+	// A small write buffer forces the partial payload onto the wire immediately;
+	// with the default dialer buffer the bytes would never leave the client.
+	dialer := &websocket.Dialer{WriteBufferSize: 1}
+	conn, _, err := dialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	t.Cleanup(func() { conn.Close() })
+
+	w, err := conn.NextWriter(websocket.TextMessage)
+	if err != nil {
+		t.Fatalf("next writer: %v", err)
+	}
+	if _, err := w.Write([]byte(`{"jsonrpc":"2.0",`)); err != nil {
+		t.Fatalf("write partial frame: %v", err)
+	}
+	// Deliberately never call w.Close() or send the rest of the message: the
+	// server has read the first fragment (NextReader returned) and reserved
+	// budget for it, but the message never finishes arriving.
+
+	budgetHeld := false
+	holdDeadline := time.Now().Add(time.Second)
+	for time.Now().Before(holdDeadline) {
+		if !srv.wsConcurrentBudget.TryAcquire(budget) {
+			budgetHeld = true
+			break
+		}
+		srv.wsConcurrentBudget.Release(budget)
+		time.Sleep(5 * time.Millisecond)
+	}
+	if !budgetHeld {
+		t.Fatal("budget should be held while partial frame is stalled")
+	}
+
+	releaseDeadline := time.Now().Add(waitTimeout + time.Second)
+	for {
+		if srv.wsConcurrentBudget.TryAcquire(budget) {
+			srv.wsConcurrentBudget.Release(budget)
+			return
+		}
+		if time.Now().After(releaseDeadline) {
+			t.Fatal("budget reserved for a stalled partial frame should be released after wsAdmissionTimeout")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
 func TestWSLargeFrameRejectedByReadLimit(t *testing.T) {
 	t.Parallel()
 
@@ -357,13 +424,30 @@ func TestWSConcurrentLargeFrames(t *testing.T) {
 	payload := makeSleepMsg(1, sleepDuration, pad)
 	frameSize := int64(len(payload))
 	srv.SetReadLimits(frameSize)
-	srv.SetWSConcurrentRequestBytes(frameSize)
+	srv.SetWSConcurrentRequestBytes(2 * frameSize)
 
 	_, wsURL := startWSTestServer(t, srv)
 	conn := dialWS(t, wsURL)
+	t.Cleanup(func() { conn.Close() })
 
 	writeWSJSON(t, conn, makeSleepMsg(1, sleepDuration, pad))
 	writeWSJSON(t, conn, makeSleepMsg(2, sleepDuration, pad))
+
+	// With budget == frameSize the two requests would serialize; with 2*frameSize
+	// both should hold budget while test_sleep runs.
+	overlapDeadline := time.Now().Add(sleepDuration)
+	var overlapped bool
+	for time.Now().Before(overlapDeadline) {
+		if !srv.wsConcurrentBudget.TryAcquire(frameSize) {
+			overlapped = true
+			break
+		}
+		srv.wsConcurrentBudget.Release(frameSize)
+		time.Sleep(5 * time.Millisecond)
+	}
+	if !overlapped {
+		t.Fatal("expected two large frames to hold byte budget concurrently")
+	}
 
 	var firstResp jsonrpcMessage
 	readWSJSON(t, conn, &firstResp)
@@ -406,6 +490,7 @@ func TestWSBudgetWaitTimeoutOnActiveBurst(t *testing.T) {
 	_, wsURL := startWSTestServer(t, srv)
 
 	conn := dialWS(t, wsURL)
+	t.Cleanup(func() { conn.Close() })
 	writeWSJSON(t, conn, makeSleepMsg(1, sleepDuration, pad))
 	writeWSJSON(t, conn, makeSleepMsg(2, sleepDuration, pad))
 
@@ -830,6 +915,45 @@ func TestCommitFrameBudgetFiresFrameAdmissionHookOnTimeout(t *testing.T) {
 	}
 }
 
+// TestCommitFrameBudgetFailureReleasesPreDecodeBudget guards against a regression
+// where commitFrameBudget cleared preDecodeHeld before a failable Acquire for
+// weight > readLimit, making the caller's releasePreDecode a no-op and permanently
+// leaking readLimit bytes from the server-wide semaphore.
+func TestCommitFrameBudgetFailureReleasesPreDecodeBudget(t *testing.T) {
+	t.Parallel()
+
+	const (
+		frameBudget = int64(100)
+		readLimit   = int64(50)
+		waitTimeout = 20 * time.Millisecond
+	)
+
+	budget := semaphore.NewWeighted(frameBudget)
+	h := newAdmissionTestHandler(frameBudget, readLimit, waitTimeout, nil)
+	h.wsConcurrentBudget = budget
+
+	if err := h.acquirePreDecode(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	// Leave no room for the extra Acquire inside commitFrameBudget.
+	if err := budget.Acquire(t.Context(), frameBudget-readLimit); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := h.commitFrameBudget(t.Context(), frameBudget); err == nil {
+		t.Fatal("expected commitFrameBudget to fail when extra budget is unavailable")
+	}
+
+	// Mirror Client.read's error path.
+	h.releasePreDecode()
+	budget.Release(frameBudget - readLimit)
+
+	if !budget.TryAcquire(frameBudget) {
+		t.Fatal("pre-decode reservation should be released after failed commitFrameBudget")
+	}
+	budget.Release(frameBudget)
+}
+
 func TestServerWSAdmissionBudgetWaitTimeoutFiresHook(t *testing.T) {
 	t.Parallel()
 
@@ -859,6 +983,7 @@ func TestServerWSAdmissionBudgetWaitTimeoutFiresHook(t *testing.T) {
 	_, wsURL := startWSTestServer(t, srv)
 
 	conn := dialWS(t, wsURL)
+	t.Cleanup(func() { conn.Close() })
 	writeWSJSON(t, conn, payload)
 
 	var firstResp jsonrpcMessage

--- a/rpc/ws_admission_test.go
+++ b/rpc/ws_admission_test.go
@@ -6,13 +6,298 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/http/httptest"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/gorilla/websocket"
 	"golang.org/x/sync/semaphore"
 )
+
+func wsTestURL(httpsrv *httptest.Server) string {
+	return "ws:" + strings.TrimPrefix(httpsrv.URL, "http:")
+}
+
+func startWSTestServer(t *testing.T, srv *Server) (*httptest.Server, string) {
+	t.Helper()
+	httpsrv := httptest.NewServer(srv.WebsocketHandler([]string{"*"}))
+	t.Cleanup(func() {
+		httpsrv.Close()
+		srv.Stop()
+	})
+	return httpsrv, wsTestURL(httpsrv)
+}
+
+func dialWS(t *testing.T, wsURL string) *websocket.Conn {
+	t.Helper()
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	return conn
+}
+
+func writeWSJSON(t *testing.T, conn *websocket.Conn, payload string) {
+	t.Helper()
+	if err := conn.WriteMessage(websocket.TextMessage, []byte(payload)); err != nil {
+		t.Fatalf("write websocket message: %v", err)
+	}
+}
+
+func readWSJSON(t *testing.T, conn *websocket.Conn, v interface{}) {
+	t.Helper()
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, data, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("read websocket message: %v", err)
+	}
+	conn.SetReadDeadline(time.Time{})
+	if err := json.Unmarshal(data, v); err != nil {
+		t.Fatalf("unmarshal websocket message: %v", err)
+	}
+}
+
+func makeSleepMsg(id int, sleep time.Duration, pad int) string {
+	return fmt.Sprintf(
+		`{"jsonrpc":"2.0","id":%d,"method":"test_sleep","params":[%d],"_pad":"%s"}`,
+		id, sleep.Nanoseconds(), strings.Repeat("x", pad),
+	)
+}
+
+func TestWSIdleConnectionsDoNotHoldBudget(t *testing.T) {
+	t.Parallel()
+
+	const (
+		frameSize = 500
+		budget    = 1000
+		idleConns = 50
+	)
+
+	srv := newTestServer()
+	srv.SetReadLimits(frameSize)
+	srv.SetWSConcurrentRequestBytes(budget)
+	_, wsURL := startWSTestServer(t, srv)
+
+	conns := make([]*websocket.Conn, idleConns)
+	for i := range conns {
+		conns[i] = dialWS(t, wsURL)
+	}
+	t.Cleanup(func() {
+		for _, c := range conns {
+			c.Close()
+		}
+	})
+
+	time.Sleep(100 * time.Millisecond)
+
+	if !srv.wsConcurrentBudget.TryAcquire(budget) {
+		t.Fatal("idle websocket connections should not hold byte budget")
+	}
+	srv.wsConcurrentBudget.Release(budget)
+}
+
+func TestWSManyIdleSubscriptions(t *testing.T) {
+	t.Parallel()
+
+	const (
+		frameSize = 500
+		budget    = 1000
+		numConns  = 100
+	)
+
+	srv := newTestServer()
+	srv.SetReadLimits(frameSize)
+	srv.SetWSConcurrentRequestBytes(budget)
+	_, wsURL := startWSTestServer(t, srv)
+
+	subReq := `{"jsonrpc":"2.0","id":1,"method":"nftest_subscribe","params":["someSubscription",1,0]}`
+	conns := make([]*websocket.Conn, numConns)
+	for i := range conns {
+		conn := dialWS(t, wsURL)
+		writeWSJSON(t, conn, subReq)
+		var subResp jsonrpcMessage
+		readWSJSON(t, conn, &subResp)
+		if subResp.Error != nil {
+			t.Fatalf("subscribe failed: %v", subResp.Error)
+		}
+		conns[i] = conn
+	}
+	t.Cleanup(func() {
+		for _, c := range conns {
+			c.Close()
+		}
+	})
+
+	time.Sleep(100 * time.Millisecond)
+
+	extra := dialWS(t, wsURL)
+	writeWSJSON(t, extra, makeSleepMsg(99, 10*time.Millisecond, 48))
+	var resp jsonrpcMessage
+	readWSJSON(t, extra, &resp)
+	if resp.Error != nil {
+		t.Fatalf("extra connection request failed: %v", resp.Error)
+	}
+}
+
+func TestWSBudgetAcquiredOnlyOnFrame(t *testing.T) {
+	t.Parallel()
+
+	const (
+		sleepDuration = 200 * time.Millisecond
+		pad           = 48
+	)
+
+	srv := newTestServer()
+	payload := makeSleepMsg(1, sleepDuration, pad)
+	frameSize := int64(len(payload))
+	srv.SetReadLimits(frameSize)
+	srv.SetWSConcurrentRequestBytes(frameSize)
+	_, wsURL := startWSTestServer(t, srv)
+
+	conn := dialWS(t, wsURL)
+	writeWSJSON(t, conn, payload)
+
+	held := false
+	deadline := time.Now().Add(sleepDuration)
+	for time.Now().Before(deadline) {
+		if !srv.wsConcurrentBudget.TryAcquire(frameSize) {
+			held = true
+			break
+		}
+		srv.wsConcurrentBudget.Release(frameSize)
+		time.Sleep(5 * time.Millisecond)
+	}
+	if !held {
+		t.Fatal("byte budget should be held while the first frame is in flight")
+	}
+
+	var resp jsonrpcMessage
+	readWSJSON(t, conn, &resp)
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %v", resp.Error)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	if !srv.wsConcurrentBudget.TryAcquire(frameSize) {
+		t.Fatal("byte budget should be fully available while blocked waiting for the next frame")
+	}
+	srv.wsConcurrentBudget.Release(frameSize)
+}
+
+func TestWSLargeFrameRejectedByReadLimit(t *testing.T) {
+	t.Parallel()
+
+	const (
+		readLimit = 256
+		budget    = 1024
+	)
+
+	srv := newTestServer()
+	srv.SetReadLimits(readLimit)
+	srv.SetWSConcurrentRequestBytes(budget)
+	_, wsURL := startWSTestServer(t, srv)
+
+	conn := dialWS(t, wsURL)
+	oversized := fmt.Sprintf(
+		`{"jsonrpc":"2.0","id":1,"method":"test_echo","params":["%s"]}`,
+		strings.Repeat("x", readLimit),
+	)
+	writeWSJSON(t, conn, oversized)
+
+	conn.SetReadDeadline(time.Now().Add(time.Second))
+	if _, _, err := conn.ReadMessage(); err == nil {
+		t.Fatal("expected connection to close after oversized frame")
+	}
+
+	if !srv.wsConcurrentBudget.TryAcquire(budget) {
+		t.Fatal("byte budget should be unchanged after read-limit rejection")
+	}
+	srv.wsConcurrentBudget.Release(budget)
+}
+
+func TestWSConcurrentLargeFrames(t *testing.T) {
+	t.Parallel()
+
+	const (
+		sleepDuration = 200 * time.Millisecond
+		pad           = 48
+	)
+
+	srv := newTestServer()
+	payload := makeSleepMsg(1, sleepDuration, pad)
+	frameSize := int64(len(payload))
+	srv.SetReadLimits(frameSize)
+	srv.SetWSConcurrentRequestBytes(frameSize)
+
+	_, wsURL := startWSTestServer(t, srv)
+	conn := dialWS(t, wsURL)
+
+	writeWSJSON(t, conn, makeSleepMsg(1, sleepDuration, pad))
+	writeWSJSON(t, conn, makeSleepMsg(2, sleepDuration, pad))
+
+	var firstResp jsonrpcMessage
+	readWSJSON(t, conn, &firstResp)
+	if string(firstResp.ID) != "1" {
+		t.Fatalf("expected first response id 1, got %s", string(firstResp.ID))
+	}
+
+	var secondResp jsonrpcMessage
+	readWSJSON(t, conn, &secondResp)
+	if string(secondResp.ID) != "2" {
+		t.Fatalf("expected second response id 2, got %s", string(secondResp.ID))
+	}
+}
+
+func TestWSBudgetWaitTimeoutOnActiveBurst(t *testing.T) {
+	t.Parallel()
+
+	const (
+		sleepDuration = 200 * time.Millisecond
+		pad           = 48
+		waitTimeout   = 50 * time.Millisecond
+	)
+
+	srv := newTestServer()
+	var (
+		mu      sync.Mutex
+		reasons []string
+	)
+	srv.SetWSAdmissionEventHook(func(reason string) {
+		mu.Lock()
+		reasons = append(reasons, reason)
+		mu.Unlock()
+	})
+	srv.SetWSAdmissionTimeout(waitTimeout)
+
+	payload := makeSleepMsg(1, sleepDuration, pad)
+	frameSize := int64(len(payload))
+	srv.SetReadLimits(frameSize)
+	srv.SetWSConcurrentRequestBytes(frameSize)
+	_, wsURL := startWSTestServer(t, srv)
+
+	conn := dialWS(t, wsURL)
+	writeWSJSON(t, conn, makeSleepMsg(1, sleepDuration, pad))
+	writeWSJSON(t, conn, makeSleepMsg(2, sleepDuration, pad))
+
+	deadline := time.Now().Add(waitTimeout + 300*time.Millisecond)
+	for {
+		mu.Lock()
+		got := append([]string(nil), reasons...)
+		mu.Unlock()
+		if len(got) > 0 {
+			if got[0] != WSAdmissionReasonBudgetWaitTimeout {
+				t.Fatalf("hook reason = %q, want %q", got[0], WSAdmissionReasonBudgetWaitTimeout)
+			}
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("expected admission hook to fire when a second frame waits on budget")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
 
 func TestWSConcurrentRequestBytesSingleInFlight(t *testing.T) {
 	t.Parallel()
@@ -376,44 +661,37 @@ func TestServerWSAdmissionBudgetWaitTimeoutFiresHook(t *testing.T) {
 	})
 	srv.SetWSAdmissionTimeout(waitTimeout)
 
-	p1, p2 := net.Pipe()
-	makeMsg := func(id int) string {
-		return fmt.Sprintf(
-			`{"jsonrpc":"2.0","id":%d,"method":"test_sleep","params":[%d],"_pad":"%s"}`,
-			id, sleepDuration.Nanoseconds(), strings.Repeat("x", pad),
-		)
-	}
-	payload := makeMsg(1)
+	payload := makeSleepMsg(1, sleepDuration, pad)
 	frameSize := int64(len(payload))
 	srv.SetReadLimits(frameSize)
 	srv.SetWSConcurrentRequestBytes(frameSize)
+	_, wsURL := startWSTestServer(t, srv)
 
-	serveDone := make(chan struct{})
-	go func() {
-		srv.ServeCodec(NewCodec(p1), 0)
-		close(serveDone)
-	}()
-	t.Cleanup(func() {
-		p2.Close()
-		p1.Close()
-		select {
-		case <-serveDone:
-		case <-time.After(2 * time.Second):
-			t.Error("ServeCodec did not exit within 2s")
-		}
-		srv.Stop()
-	})
+	conn := dialWS(t, wsURL)
+	writeWSJSON(t, conn, payload)
 
-	writeReq := func(id int) {
-		if _, err := io.WriteString(p2, makeMsg(id)); err != nil {
-			t.Fatalf("write request %d: %v", id, err)
-		}
+	var firstResp jsonrpcMessage
+	readWSJSON(t, conn, &firstResp)
+	if firstResp.Error != nil {
+		t.Fatalf("unexpected error: %v", firstResp.Error)
 	}
 
-	// Request 1 holds the byte budget while it sleeps. The read loop then waits
-	// for budget before the next read and should time out, even with no second
-	// request sent.
-	writeReq(1)
+	// After the first request completes the read loop blocks in NextReader without
+	// holding budget. The hook must not fire while idle.
+	idleDeadline := time.Now().Add(waitTimeout + 200*time.Millisecond)
+	for time.Now().Before(idleDeadline) {
+		mu.Lock()
+		got := append([]string(nil), reasons...)
+		mu.Unlock()
+		if len(got) > 0 {
+			t.Fatalf("hook fired while idle in NextReader: %v", got)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// Hold budget again and send a second frame while it is exhausted.
+	writeWSJSON(t, conn, makeSleepMsg(2, sleepDuration, pad))
+	writeWSJSON(t, conn, makeSleepMsg(3, sleepDuration, pad))
 
 	deadline := time.Now().Add(waitTimeout + 300*time.Millisecond)
 	for {


### PR DESCRIPTION
## Summary
- Moves pre-decode budget acquisition (`acquirePreDecode`/`releasePreDecode`) out of the generic `Client.read` loop and into each codec's `readBatch`, wired via `setBudgetHandler` / `budgetHandlerSetter` on `jsonCodec` and `websocketCodec`.
- On **WebSocket**, budget is acquired only after a frame starts arriving (`NextReader()`), not while idle in `NextReader()`. On **IPC/stdio**, budget is still reserved before the blocking read — idle connections there can still hold `readLimit` bytes indefinitely (documented on `SetWSConcurrentRequestBytes` and in `jsonCodec.readBatch`).
- Adds a dedicated `websocketCodec.readBatch` that calls `NextReader()` before `acquirePreDecode`, so frames rejected by gorilla's read limit (`websocket.ErrReadLimit`) never consume byte budget.
- Bounds in-progress WebSocket decode with `wsAdmissionTimeout` (`beginDecodeRead` / `endDecodeRead`), coordinated with `pingLoop` via `decodeReadActive`, so a peer that sends one fragment and stalls (while still ponging) cannot hold pre-decode budget indefinitely.
- Tracks `preDecodeHeld` on the handler so `commitFrameBudget` / `releasePreDecode` reconcile correctly for wired codecs, fall back safely for unwired/wrapped codecs, and release pre-decode reservations on failed oversize-frame commits instead of leaking server-wide budget.
- Introduces `WSAdmissionReasonOversizeFrame`, fired via the admission event hook when gorilla's read limit rejects a message on the first frame or partway through continuation frames.
- Returns JSON-RPC **-32005** (`errcodeBudgetWaitTimeout`) to the peer on genuine pre-decode budget-wait timeouts (`DeadlineExceeded`) before the connection closes — not on normal teardown (`context.Canceled`). Oversize-frame rejections still rely on gorilla's own `close(1009, "message too big")` handshake; no JSON-RPC error is added there.
- Expands `rpc/ws_admission_test.go` with real WebSocket-server-backed coverage: idle connections holding no budget, subscriptions, budget held only while a frame is in flight, partial-frame stall release, oversized/fragmented hook firing, concurrent large frames under `2×` budget, peer receipt of `-32005`, idle vs. active budget-wait-timeout hook behavior, passthrough-codec panic regression, and `commitFrameBudget` budget-leak regression.

## Why
Previously the pre-decode budget was acquired unconditionally before every read in the client's shared read loop, including while a WebSocket connection was idle waiting on `NextReader()`. Idle connections could hold concurrent-byte budget indefinitely and starve others. Moving acquisition into codec-specific read paths ties WebSocket budget to frames that have actually started arriving, and the oversize-frame hook closes a metrics gap for gorilla read-limit rejections.

A second gap remained on WebSocket: after `NextReader()` returned, a peer could dribble continuation frames (or stall mid-message while ponging) and hold budget for as long as it liked. `wsAdmissionTimeout` now bounds that in-progress decode window.

Separately, budget-wait timeouts used to drop connections silently. Clients now receive `-32005` on genuine congestion timeouts. Review follow-ups also fixed misclassification of connection teardown as a budget timeout, semaphore panic/over-release for codecs that don't wire in the handler, and a server-wide budget leak when `commitFrameBudget` failed after clearing `preDecodeHeld` too early.

## Test plan
- [x] `go test ./rpc/...`