### PR TITLE
Add seidroid AI PR review and assistant workflows

### DIFF
--- a/.github/workflows/ai-assist.yml
+++ b/.github/workflows/ai-assist.yml
@@ -1,0 +1,22 @@
+name: AI Assistant
+on:
+  issue_comment:
+    types: [ created ]
+  pull_request_review_comment:
+    types: [ created ]
+  pull_request_review:
+    types: [ submitted ]
+jobs:
+  assistant:
+    # See: https://github.com/sei-protocol/uci/releases/tag/v0.0.13
+    uses: sei-protocol/uci/.github/workflows/ai-assistant.yml@29a9c73301b2218e1940cf3f9a2c3d34c86fbd9a
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+    secrets: inherit
+    with:
+      # See: https://github.com/sei-protocol/uci/releases/tag/v0.0.13
+      uci-ref: 29a9c73301b2218e1940cf3f9a2c3d34c86fbd9a
+      allowed-team: 'sei-protocol/sei-core'

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -1,0 +1,18 @@
+name: AI Review
+on:
+  pull_request:
+    types: [ opened, ready_for_review, synchronize, reopened ]
+jobs:
+  ai-review:
+    # See: https://github.com/sei-protocol/uci/releases/tag/v0.0.13
+    uses: sei-protocol/uci/.github/workflows/ai-review.yml@29a9c73301b2218e1940cf3f9a2c3d34c86fbd9a
+    permissions:
+      contents: read
+      pull-requests: write
+      checks: write
+      id-token: write
+    secrets: inherit
+    with:
+      # See: https://github.com/sei-protocol/uci/releases/tag/v0.0.13
+      uci-ref: 29a9c73301b2218e1940cf3f9a2c3d34c86fbd9a
+      enable-cursor: false # Disabled for now since there is a dedicated Bugbot flow built into Cursor currently enabled on repo.


### PR DESCRIPTION
## Summary
- Wires up the `seidroid` AI reviewer/assistant on this repo, mirroring the setup already in `sei-chain`.
- `ai-review.yml`: runs on PR open/sync, triggers the UCI reusable review workflow (Codex + Claude synthesis; Cursor scout disabled since Bugbot already covers this repo).
- `ai-assist.yml`: enables `@seidroid` conversational responses on PR/issue comments, gated to `sei-protocol/sei-core`.
- Both pinned to `sei-protocol/uci@29a9c73301b2218e1940cf3f9a2c3d34c86fbd9a` (v0.0.13).

## Notes
- Relies on org-level secrets/variables (`PLATFORM_CODE_AGENT_*`) via `secrets: inherit` — no new secrets added here.
- Requires the `seidroid` GitHub App to be installed on this repo for the workflows to authenticate; please confirm app install status.

## Test plan
- [ ] Open a test PR against this branch and confirm the `AI Review` check runs and posts a review.
- [ ] Comment `@seidroid` on a PR and confirm the assistant responds.