### PR TITLE
Enable seidroid xreview, bump uci to v0.0.15

### DIFF
--- a/.github/workflows/ai-assist.yml
+++ b/.github/workflows/ai-assist.yml
@@ -8,8 +8,8 @@ on:
     types: [ submitted ]
 jobs:
   assistant:
-    # See: https://github.com/sei-protocol/uci/releases/tag/v0.0.13
-    uses: sei-protocol/uci/.github/workflows/ai-assistant.yml@29a9c73301b2218e1940cf3f9a2c3d34c86fbd9a
+    # See: https://github.com/sei-protocol/uci/releases/tag/v0.0.15
+    uses: sei-protocol/uci/.github/workflows/ai-assistant.yml@65901242783550521f25a19199a6b10e54550b97
     permissions:
       contents: read
       pull-requests: write
@@ -17,6 +17,6 @@ jobs:
       id-token: write
     secrets: inherit
     with:
-      # See: https://github.com/sei-protocol/uci/releases/tag/v0.0.13
-      uci-ref: 29a9c73301b2218e1940cf3f9a2c3d34c86fbd9a
+      # See: https://github.com/sei-protocol/uci/releases/tag/v0.0.15
+      uci-ref: 65901242783550521f25a19199a6b10e54550b97
       allowed-team: 'sei-protocol/sei-core'

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -4,8 +4,8 @@ on:
     types: [ opened, ready_for_review, synchronize, reopened ]
 jobs:
   ai-review:
-    # See: https://github.com/sei-protocol/uci/releases/tag/v0.0.13
-    uses: sei-protocol/uci/.github/workflows/ai-review.yml@29a9c73301b2218e1940cf3f9a2c3d34c86fbd9a
+    # See: https://github.com/sei-protocol/uci/releases/tag/v0.0.15
+    uses: sei-protocol/uci/.github/workflows/ai-review.yml@65901242783550521f25a19199a6b10e54550b97
     permissions:
       contents: read
       pull-requests: write
@@ -13,6 +13,6 @@ jobs:
       id-token: write
     secrets: inherit
     with:
-      # See: https://github.com/sei-protocol/uci/releases/tag/v0.0.13
-      uci-ref: 29a9c73301b2218e1940cf3f9a2c3d34c86fbd9a
+      # See: https://github.com/sei-protocol/uci/releases/tag/v0.0.15
+      uci-ref: 65901242783550521f25a19199a6b10e54550b97
       enable-cursor: false # Disabled for now since there is a dedicated Bugbot flow built into Cursor currently enabled on repo.

--- a/.github/workflows/seidroid-xreview.yml
+++ b/.github/workflows/seidroid-xreview.yml
@@ -1,0 +1,38 @@
+name: seidroid xreview
+# Comment `seidroid xreview` on a PR to run the on-demand, sandbox-backed agentic review.
+# Thin caller: the logic is the reusable workflow in sei-protocol/uci; bump both refs below
+# (to the next release's commit SHA) to adopt a new xreview release. The verdict is posted to
+# the PR as one sticky comment when a review produces one.
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  xreview:
+    # Pre-filter that MIRRORS the reusable workflow's trust gate locally (PR comment, a
+    # human, a trusted author, and the command mentioned) so an unrelated, bot-echoed, or
+    # untrusted comment never dispatches the workflow — defense in depth that does not rely
+    # on the cross-repo guard alone. The reusable workflow's guard remains the authoritative
+    # exact-command + author check; overlapping runs on one PR are handled by its job-level
+    # concurrency group.
+    if: >-
+      ${{ github.event.issue.pull_request
+      && github.event.comment.user.type != 'Bot'
+      && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+      && contains(github.event.comment.body, 'seidroid xreview') }}
+    # Pinned to the immutable commit for uci v0.0.15 — a mutable tag would let anyone
+    # able to move it run code in this repo's Actions context with the passed secret.
+    # Matches how ai-review/ai-assist pin uci (a full commit SHA).
+    uses: sei-protocol/uci/.github/workflows/seidroid-xreview.yml@65901242783550521f25a19199a6b10e54550b97  # uci v0.0.15
+    permissions:
+      pull-requests: write   # upsert the one sticky verdict comment
+      contents: read         # read PR metadata
+      # id-token: write intentionally omitted — xreview mints its omnigent bearer via the
+      # client-credentials grant (no OIDC exchange), unlike ai-review/ai-assist which use
+      # Anthropic workload-identity federation.
+    # Pass ONLY the one secret xreview needs — not `secrets: inherit`, which would hand the
+    # cross-repo reusable workflow every secret on this repo (release, ECR/GHCR, Slack, …).
+    secrets:
+      OMNIGENT_M2M_CLIENT_SECRET: ${{ secrets.OMNIGENT_M2M_CLIENT_SECRET }}
+    with:
+      uci-ref: 65901242783550521f25a19199a6b10e54550b97   # uci v0.0.15 (same commit as `uses:`)


### PR DESCRIPTION
Enables **seidroid xreview** on sei-go-ethereum — the on-demand, sandbox-backed agentic review, a third seidroid capability alongside the `ai-review` / `ai-assist` this repo already runs. Also bumps those two existing workflows to the same uci release for consistency.

Linear: PLT-873

## What this adds

New file `.github/workflows/seidroid-xreview.yml` — a thin caller that `uses:` the uci reusable workflow, so the review logic lives in `sei-protocol/uci`:
- Pinned to the **uci v0.0.15 commit SHA** (`6590124`) on both `uses:` and `uci-ref` — a fixed ref, never a moving tag.
- Passes **only** `OMNIGENT_M2M_CLIENT_SECRET` (not `secrets: inherit`), so the cross-repo reusable workflow never receives this repo's other secrets.
- A local `if:` gate mirrors the reusable workflow's trust check (PR comment, non-bot, `OWNER`/`MEMBER`/`COLLABORATOR`, command mentioned) so an unrelated or untrusted comment never dispatches it.
- Comment `seidroid xreview` on a PR to trigger it; the verdict posts as a single sticky comment.

## What this changes

`ai-review.yml` and `ai-assist.yml` bumped from uci v0.0.13 (`29a9c73`) to v0.0.15 (`6590124`), same commit as xreview, so all three workflows track one release.

## Prerequisites (need verification before this is live)

- `sei-droid` GitHub App installed on this repo
- `uci-default` runner-group access granted to this repo
- `OMNIGENT_M2M_CLIENT_SECRET` secret configured (not currently visible at the repo-secret level — only `CODECOV_TOKEN` shows; may be an org-level secret, or may still need adding)

## Test plan

- [ ] Confirm `sei-droid` app + runner-group access + `OMNIGENT_M2M_CLIENT_SECRET` are in place
- [ ] Open a test PR, comment `seidroid xreview`, confirm sticky verdict comment is posted
- [ ] Confirm `ai-review` / `ai-assist` still run correctly on the bumped uci ref