### PR TITLE
core/vm: skip full code load when code cannot be a 7702 delegation (CON-361)

### DIFF
--- a/core/types/tx_setcode.go
+++ b/core/types/tx_setcode.go
@@ -33,9 +33,16 @@ import (
 // another account.
 var DelegationPrefix = []byte{0xef, 0x01, 0x00}
 
+// IsDelegationDesignatorLength reports whether n is the fixed EIP-7702
+// delegation designator size (DelegationPrefix followed by a 20-byte address).
+// This is necessary but not sufficient for ParseDelegation to succeed.
+func IsDelegationDesignatorLength(n int) bool {
+	return n == len(DelegationPrefix)+common.AddressLength
+}
+
 // ParseDelegation tries to parse the address from a delegation slice.
 func ParseDelegation(b []byte) (common.Address, bool) {
-	if len(b) != 23 || !bytes.HasPrefix(b, DelegationPrefix) {
+	if !IsDelegationDesignatorLength(len(b)) || !bytes.HasPrefix(b, DelegationPrefix) {
 		return common.Address{}, false
 	}
 	return common.BytesToAddress(b[len(DelegationPrefix):]), true

--- a/core/vm/eip7702_code_read_test.go
+++ b/core/vm/eip7702_code_read_test.go
@@ -1,0 +1,257 @@
+// Copyright 2026 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+
+package vm
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/stateless"
+	"github.com/ethereum/go-ethereum/core/tracing"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/trie/utils"
+	"github.com/holiman/uint256"
+)
+
+// stubStateDB is a minimal StateDB for EIP-7702 code-load tests.
+type stubStateDB struct {
+	codes            map[common.Address][]byte
+	accessList       map[common.Address]struct{}
+	getCodeCalls     int
+	getCodeSizeCalls int
+}
+
+func newStubStateDB() *stubStateDB {
+	return &stubStateDB{
+		codes:      make(map[common.Address][]byte),
+		accessList: make(map[common.Address]struct{}),
+	}
+}
+
+func (s *stubStateDB) setCode(addr common.Address, code []byte) {
+	s.codes[addr] = code
+}
+
+func (s *stubStateDB) CreateAccount(common.Address)              {}
+func (s *stubStateDB) CreateContract(common.Address)             {}
+func (s *stubStateDB) SubBalance(common.Address, *uint256.Int, tracing.BalanceChangeReason) uint256.Int {
+	return *uint256.NewInt(0)
+}
+func (s *stubStateDB) AddBalance(common.Address, *uint256.Int, tracing.BalanceChangeReason) uint256.Int {
+	return *uint256.NewInt(0)
+}
+func (s *stubStateDB) GetBalance(common.Address) *uint256.Int { return uint256.NewInt(0) }
+func (s *stubStateDB) GetNonce(common.Address) uint64         { return 0 }
+func (s *stubStateDB) SetNonce(common.Address, uint64, tracing.NonceChangeReason) {
+}
+func (s *stubStateDB) GetCodeHash(addr common.Address) common.Hash {
+	code := s.codes[addr]
+	if len(code) == 0 {
+		return types.EmptyCodeHash
+	}
+	return crypto.Keccak256Hash(code)
+}
+func (s *stubStateDB) GetCode(addr common.Address) []byte {
+	s.getCodeCalls++
+	return s.codes[addr]
+}
+func (s *stubStateDB) SetCode(addr common.Address, code []byte) []byte {
+	prev := s.codes[addr]
+	s.codes[addr] = code
+	return prev
+}
+func (s *stubStateDB) GetCodeSize(addr common.Address) int {
+	s.getCodeSizeCalls++
+	return len(s.codes[addr])
+}
+func (s *stubStateDB) AddRefund(uint64)  {}
+func (s *stubStateDB) SubRefund(uint64)  {}
+func (s *stubStateDB) GetRefund() uint64 { return 0 }
+func (s *stubStateDB) GetCommittedState(common.Address, common.Hash) common.Hash {
+	return common.Hash{}
+}
+func (s *stubStateDB) GetState(common.Address, common.Hash) common.Hash { return common.Hash{} }
+func (s *stubStateDB) SetState(common.Address, common.Hash, common.Hash) common.Hash {
+	return common.Hash{}
+}
+func (s *stubStateDB) GetStorageRoot(common.Address) common.Hash { return common.Hash{} }
+func (s *stubStateDB) GetTransientState(common.Address, common.Hash) common.Hash {
+	return common.Hash{}
+}
+func (s *stubStateDB) SetTransientState(common.Address, common.Hash, common.Hash) {}
+func (s *stubStateDB) SelfDestruct(common.Address) uint256.Int {
+	return *uint256.NewInt(0)
+}
+func (s *stubStateDB) HasSelfDestructed(common.Address) bool { return false }
+func (s *stubStateDB) SelfDestruct6780(common.Address) (uint256.Int, bool) {
+	return *uint256.NewInt(0), false
+}
+func (s *stubStateDB) Exist(common.Address) bool  { return true }
+func (s *stubStateDB) Empty(common.Address) bool  { return false }
+func (s *stubStateDB) AddressInAccessList(addr common.Address) bool {
+	_, ok := s.accessList[addr]
+	return ok
+}
+func (s *stubStateDB) SlotInAccessList(common.Address, common.Hash) (bool, bool) {
+	return false, false
+}
+func (s *stubStateDB) AddAddressToAccessList(addr common.Address) {
+	s.accessList[addr] = struct{}{}
+}
+func (s *stubStateDB) AddSlotToAccessList(common.Address, common.Hash) {}
+func (s *stubStateDB) PointCache() *utils.PointCache                  { return nil }
+func (s *stubStateDB) Prepare(params.Rules, common.Address, common.Address, *common.Address, []common.Address, types.AccessList) {
+}
+func (s *stubStateDB) RevertToSnapshot(int) {}
+func (s *stubStateDB) Snapshot() int        { return 0 }
+func (s *stubStateDB) AddLog(*types.Log)    {}
+func (s *stubStateDB) AddPreimage(common.Hash, []byte) {
+}
+func (s *stubStateDB) Witness() *stateless.Witness { return nil }
+func (s *stubStateDB) AccessEvents() *AccessEvents { return nil }
+func (s *stubStateDB) Finalise(bool)               {}
+func (s *stubStateDB) Error() error                { return nil }
+func (s *stubStateDB) SetBalance(common.Address, *uint256.Int, tracing.BalanceChangeReason) {
+}
+func (s *stubStateDB) SetStorage(common.Address, map[common.Hash]common.Hash) {}
+func (s *stubStateDB) Commit(uint64, bool, bool) (common.Hash, error) {
+	return common.Hash{}, nil
+}
+func (s *stubStateDB) SetTxContext(common.Hash, int) {}
+func (s *stubStateDB) Copy() StateDB                 { return s }
+func (s *stubStateDB) IntermediateRoot(bool) common.Hash {
+	return common.Hash{}
+}
+func (s *stubStateDB) GetLogs(common.Hash, uint64, common.Hash) []*types.Log {
+	return nil
+}
+func (s *stubStateDB) TxIndex() int { return 0 }
+func (s *stubStateDB) Preimages() map[common.Hash][]byte {
+	return nil
+}
+func (s *stubStateDB) Logs() []*types.Log { return nil }
+func (s *stubStateDB) SetEVM(*EVM)        {}
+
+func newPragueTestEVM(t *testing.T, statedb StateDB) *EVM {
+	t.Helper()
+	vmctx := BlockContext{
+		CanTransfer: func(StateDB, common.Address, *uint256.Int) bool { return true },
+		Transfer:    func(StateDB, common.Address, common.Address, *uint256.Int) {},
+		BlockNumber: big.NewInt(1),
+		Time:        1,
+		Random:      &common.Hash{}, // post-merge; required for Prague rules
+	}
+	return NewEVM(vmctx, statedb, params.MergedTestChainConfig, Config{}, nil)
+}
+
+func TestResolveCodeHashSkipsFullCodeForNonDelegation(t *testing.T) {
+	statedb := newStubStateDB()
+	addr := common.BytesToAddress([]byte("large-contract"))
+	code := make([]byte, params.MaxCodeSize)
+	code[0] = 0x00 // STOP
+	statedb.setCode(addr, code)
+
+	evm := newPragueTestEVM(t, statedb)
+	if !evm.chainRules.IsPrague {
+		t.Fatal("expected Prague rules")
+	}
+
+	got := evm.resolveCodeHash(addr)
+	want := crypto.Keccak256Hash(code)
+	if got != want {
+		t.Fatalf("code hash mismatch: got %x want %x", got, want)
+	}
+	if statedb.getCodeCalls != 0 {
+		t.Fatalf("GetCode calls = %d, want 0 for non-delegation sized code", statedb.getCodeCalls)
+	}
+	if statedb.getCodeSizeCalls == 0 {
+		t.Fatal("expected GetCodeSize to be consulted")
+	}
+}
+
+func TestResolveCodeHashLoadsDelegationDesignator(t *testing.T) {
+	statedb := newStubStateDB()
+	target := common.BytesToAddress([]byte("delegate-target"))
+	eoa := common.BytesToAddress([]byte("delegated-eoa"))
+	targetCode := []byte{0x00}
+	statedb.setCode(target, targetCode)
+	statedb.setCode(eoa, types.AddressToDelegation(target))
+
+	evm := newPragueTestEVM(t, statedb)
+
+	got := evm.resolveCodeHash(eoa)
+	want := crypto.Keccak256Hash(targetCode)
+	if got != want {
+		t.Fatalf("delegated code hash mismatch: got %x want %x", got, want)
+	}
+	if statedb.getCodeCalls == 0 {
+		t.Fatal("expected GetCode for 23-byte delegation designator")
+	}
+}
+
+func TestCallVariantGasEIP7702SkipsFullCodeForNonDelegation(t *testing.T) {
+	statedb := newStubStateDB()
+	addr := common.BytesToAddress([]byte("large-contract"))
+	statedb.setCode(addr, make([]byte, params.MaxCodeSize))
+	statedb.AddAddressToAccessList(addr)
+
+	evm := newPragueTestEVM(t, statedb)
+	contract := NewContract(common.Address{}, common.Address{}, uint256.NewInt(0), 1_000_000, nil)
+
+	stack := Newstack()
+	defer returnStack(stack)
+	stack.Push(uint256.NewInt(0))                               // value (Back(2))
+	stack.Push(new(uint256.Int).SetBytes(addr.Bytes()))         // addr (Back(1))
+	stack.Push(uint256.NewInt(100_000))                         // gas (Back(0))
+
+	before := statedb.getCodeCalls
+	if _, err := gasCallEIP7702(evm, contract, stack, NewMemory(), 0); err != nil {
+		t.Fatalf("gasCallEIP7702: %v", err)
+	}
+	if statedb.getCodeCalls != before {
+		t.Fatalf("GetCode calls increased by %d, want 0 for non-delegation sized code", statedb.getCodeCalls-before)
+	}
+	if statedb.getCodeSizeCalls == 0 {
+		t.Fatal("expected GetCodeSize to be consulted")
+	}
+}
+
+func TestCallVariantGasEIP7702ChargesDelegationTarget(t *testing.T) {
+	statedb := newStubStateDB()
+	target := common.BytesToAddress([]byte("delegate-target"))
+	eoa := common.BytesToAddress([]byte("delegated-eoa"))
+	statedb.setCode(target, []byte{0x00})
+	statedb.setCode(eoa, types.AddressToDelegation(target))
+	statedb.AddAddressToAccessList(eoa)
+
+	evm := newPragueTestEVM(t, statedb)
+	contract := NewContract(common.Address{}, common.Address{}, uint256.NewInt(0), 1_000_000, nil)
+	gasBefore := contract.Gas
+
+	stack := Newstack()
+	defer returnStack(stack)
+	stack.Push(uint256.NewInt(0))
+	stack.Push(new(uint256.Int).SetBytes(eoa.Bytes()))
+	stack.Push(uint256.NewInt(100_000))
+
+	dyn, err := gasCallEIP7702(evm, contract, stack, NewMemory(), 0)
+	if err != nil {
+		t.Fatalf("gasCallEIP7702: %v", err)
+	}
+	if statedb.getCodeCalls == 0 {
+		t.Fatal("expected GetCode for delegation designator")
+	}
+	if !statedb.AddressInAccessList(target) {
+		t.Fatal("expected delegation target to be added to access list")
+	}
+	if dyn < params.ColdAccountAccessCostEIP2929 {
+		t.Fatalf("dynamic gas %d, want at least cold account access %d", dyn, params.ColdAccountAccessCostEIP2929)
+	}
+	if contract.Gas != gasBefore {
+		t.Fatalf("contract gas after calculator = %d, want %d (charges returned to dynamic gas)", contract.Gas, gasBefore)
+	}
+}

--- a/core/vm/eip7702_code_read_test.go
+++ b/core/vm/eip7702_code_read_test.go
@@ -1,5 +1,18 @@
 // Copyright 2026 The go-ethereum Authors
 // This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
 package vm
 
@@ -36,8 +49,8 @@ func (s *stubStateDB) setCode(addr common.Address, code []byte) {
 	s.codes[addr] = code
 }
 
-func (s *stubStateDB) CreateAccount(common.Address)              {}
-func (s *stubStateDB) CreateContract(common.Address)             {}
+func (s *stubStateDB) CreateAccount(common.Address)  {}
+func (s *stubStateDB) CreateContract(common.Address) {}
 func (s *stubStateDB) SubBalance(common.Address, *uint256.Int, tracing.BalanceChangeReason) uint256.Int {
 	return *uint256.NewInt(0)
 }
@@ -90,8 +103,8 @@ func (s *stubStateDB) HasSelfDestructed(common.Address) bool { return false }
 func (s *stubStateDB) SelfDestruct6780(common.Address) (uint256.Int, bool) {
 	return *uint256.NewInt(0), false
 }
-func (s *stubStateDB) Exist(common.Address) bool  { return true }
-func (s *stubStateDB) Empty(common.Address) bool  { return false }
+func (s *stubStateDB) Exist(common.Address) bool { return true }
+func (s *stubStateDB) Empty(common.Address) bool { return false }
 func (s *stubStateDB) AddressInAccessList(addr common.Address) bool {
 	_, ok := s.accessList[addr]
 	return ok
@@ -103,7 +116,7 @@ func (s *stubStateDB) AddAddressToAccessList(addr common.Address) {
 	s.accessList[addr] = struct{}{}
 }
 func (s *stubStateDB) AddSlotToAccessList(common.Address, common.Hash) {}
-func (s *stubStateDB) PointCache() *utils.PointCache                  { return nil }
+func (s *stubStateDB) PointCache() *utils.PointCache                   { return nil }
 func (s *stubStateDB) Prepare(params.Rules, common.Address, common.Address, *common.Address, []common.Address, types.AccessList) {
 }
 func (s *stubStateDB) RevertToSnapshot(int) {}
@@ -122,7 +135,9 @@ func (s *stubStateDB) Commit(uint64, bool, bool) (common.Hash, error) {
 	return common.Hash{}, nil
 }
 func (s *stubStateDB) SetTxContext(common.Hash, int) {}
-func (s *stubStateDB) Copy() StateDB                 { return s }
+func (s *stubStateDB) Copy() StateDB {
+	panic("stubStateDB.Copy is not implemented")
+}
 func (s *stubStateDB) IntermediateRoot(bool) common.Hash {
 	return common.Hash{}
 }
@@ -189,7 +204,30 @@ func TestResolveCodeHashLoadsDelegationDesignator(t *testing.T) {
 		t.Fatalf("delegated code hash mismatch: got %x want %x", got, want)
 	}
 	if statedb.getCodeCalls == 0 {
-		t.Fatal("expected GetCode for 23-byte delegation designator")
+		t.Fatal("expected GetCode for designator-sized delegation code")
+	}
+}
+
+func TestResolveCodeHashDesignatorLengthWrongPrefix(t *testing.T) {
+	statedb := newStubStateDB()
+	addr := common.BytesToAddress([]byte("almost-designator"))
+	// Exact designator length, but not a delegation prefix — size gate opens,
+	// ParseDelegation must still reject and fall back to the account hash.
+	code := make([]byte, len(types.DelegationPrefix)+common.AddressLength)
+	code[0] = 0x00
+	statedb.setCode(addr, code)
+
+	evm := newPragueTestEVM(t, statedb)
+	got := evm.resolveCodeHash(addr)
+	want := crypto.Keccak256Hash(code)
+	if got != want {
+		t.Fatalf("code hash mismatch: got %x want %x", got, want)
+	}
+	if statedb.getCodeCalls == 0 {
+		t.Fatal("expected GetCode when size matches designator length")
+	}
+	if _, ok := types.ParseDelegation(code); ok {
+		t.Fatal("test setup: code must not parse as a delegation")
 	}
 }
 
@@ -204,9 +242,9 @@ func TestCallVariantGasEIP7702SkipsFullCodeForNonDelegation(t *testing.T) {
 
 	stack := Newstack()
 	defer returnStack(stack)
-	stack.Push(uint256.NewInt(0))                               // value (Back(2))
-	stack.Push(new(uint256.Int).SetBytes(addr.Bytes()))         // addr (Back(1))
-	stack.Push(uint256.NewInt(100_000))                         // gas (Back(0))
+	stack.Push(uint256.NewInt(0))                       // value (Back(2))
+	stack.Push(new(uint256.Int).SetBytes(addr.Bytes())) // addr (Back(1))
+	stack.Push(uint256.NewInt(100_000))                 // gas (Back(0))
 
 	before := statedb.getCodeCalls
 	if _, err := gasCallEIP7702(evm, contract, stack, NewMemory(), 0); err != nil {
@@ -253,5 +291,31 @@ func TestCallVariantGasEIP7702ChargesDelegationTarget(t *testing.T) {
 	}
 	if contract.Gas != gasBefore {
 		t.Fatalf("contract gas after calculator = %d, want %d (charges returned to dynamic gas)", contract.Gas, gasBefore)
+	}
+}
+
+func TestCallVariantGasEIP7702DesignatorLengthWrongPrefix(t *testing.T) {
+	statedb := newStubStateDB()
+	addr := common.BytesToAddress([]byte("almost-designator"))
+	code := make([]byte, len(types.DelegationPrefix)+common.AddressLength)
+	code[0] = 0x00
+	statedb.setCode(addr, code)
+	statedb.AddAddressToAccessList(addr)
+
+	evm := newPragueTestEVM(t, statedb)
+	contract := NewContract(common.Address{}, common.Address{}, uint256.NewInt(0), 1_000_000, nil)
+
+	stack := Newstack()
+	defer returnStack(stack)
+	stack.Push(uint256.NewInt(0))
+	stack.Push(new(uint256.Int).SetBytes(addr.Bytes()))
+	stack.Push(uint256.NewInt(100_000))
+
+	before := statedb.getCodeCalls
+	if _, err := gasCallEIP7702(evm, contract, stack, NewMemory(), 0); err != nil {
+		t.Fatalf("gasCallEIP7702: %v", err)
+	}
+	if statedb.getCodeCalls <= before {
+		t.Fatal("expected GetCode when size matches designator length")
 	}
 }

--- a/core/vm/eip7702_code_read_test.go
+++ b/core/vm/eip7702_code_read_test.go
@@ -167,7 +167,6 @@ func TestResolveCodeHashSkipsFullCodeForNonDelegation(t *testing.T) {
 	statedb := newStubStateDB()
 	addr := common.BytesToAddress([]byte("large-contract"))
 	code := make([]byte, params.MaxCodeSize)
-	code[0] = 0x00 // STOP
 	statedb.setCode(addr, code)
 
 	evm := newPragueTestEVM(t, statedb)
@@ -214,7 +213,7 @@ func TestResolveCodeHashDesignatorLengthWrongPrefix(t *testing.T) {
 	// Exact designator length, but not a delegation prefix — size gate opens,
 	// ParseDelegation must still reject and fall back to the account hash.
 	code := make([]byte, len(types.DelegationPrefix)+common.AddressLength)
-	code[0] = 0x00
+	code[0] = 0xff
 	statedb.setCode(addr, code)
 
 	evm := newPragueTestEVM(t, statedb)
@@ -262,19 +261,37 @@ func TestCallVariantGasEIP7702ChargesDelegationTarget(t *testing.T) {
 	statedb := newStubStateDB()
 	target := common.BytesToAddress([]byte("delegate-target"))
 	eoa := common.BytesToAddress([]byte("delegated-eoa"))
+	baselineAddr := common.BytesToAddress([]byte("baseline-eoa"))
 	statedb.setCode(target, []byte{0x00})
 	statedb.setCode(eoa, types.AddressToDelegation(target))
+	// Same length as a designator, but wrong prefix — no target access charge.
+	baselineCode := make([]byte, len(types.DelegationPrefix)+common.AddressLength)
+	baselineCode[0] = 0xff
+	statedb.setCode(baselineAddr, baselineCode)
 	statedb.AddAddressToAccessList(eoa)
+	statedb.AddAddressToAccessList(baselineAddr)
 
 	evm := newPragueTestEVM(t, statedb)
+	pushCallStack := func(addr common.Address) *Stack {
+		stack := Newstack()
+		stack.Push(uint256.NewInt(0))
+		stack.Push(new(uint256.Int).SetBytes(addr.Bytes()))
+		stack.Push(uint256.NewInt(100_000))
+		return stack
+	}
+
+	baselineContract := NewContract(common.Address{}, common.Address{}, uint256.NewInt(0), 1_000_000, nil)
+	baselineStack := pushCallStack(baselineAddr)
+	baseline, err := gasCallEIP7702(evm, baselineContract, baselineStack, NewMemory(), 0)
+	returnStack(baselineStack)
+	if err != nil {
+		t.Fatalf("baseline gasCallEIP7702: %v", err)
+	}
+
 	contract := NewContract(common.Address{}, common.Address{}, uint256.NewInt(0), 1_000_000, nil)
 	gasBefore := contract.Gas
-
-	stack := Newstack()
+	stack := pushCallStack(eoa)
 	defer returnStack(stack)
-	stack.Push(uint256.NewInt(0))
-	stack.Push(new(uint256.Int).SetBytes(eoa.Bytes()))
-	stack.Push(uint256.NewInt(100_000))
 
 	dyn, err := gasCallEIP7702(evm, contract, stack, NewMemory(), 0)
 	if err != nil {
@@ -286,8 +303,9 @@ func TestCallVariantGasEIP7702ChargesDelegationTarget(t *testing.T) {
 	if !statedb.AddressInAccessList(target) {
 		t.Fatal("expected delegation target to be added to access list")
 	}
-	if dyn < params.ColdAccountAccessCostEIP2929 {
-		t.Fatalf("dynamic gas %d, want at least cold account access %d", dyn, params.ColdAccountAccessCostEIP2929)
+	want := baseline + params.ColdAccountAccessCostEIP2929
+	if dyn != want {
+		t.Fatalf("dynamic gas %d, want baseline %d + cold access %d = %d", dyn, baseline, params.ColdAccountAccessCostEIP2929, want)
 	}
 	if contract.Gas != gasBefore {
 		t.Fatalf("contract gas after calculator = %d, want %d (charges returned to dynamic gas)", contract.Gas, gasBefore)
@@ -298,7 +316,7 @@ func TestCallVariantGasEIP7702DesignatorLengthWrongPrefix(t *testing.T) {
 	statedb := newStubStateDB()
 	addr := common.BytesToAddress([]byte("almost-designator"))
 	code := make([]byte, len(types.DelegationPrefix)+common.AddressLength)
-	code[0] = 0x00
+	code[0] = 0xff
 	statedb.setCode(addr, code)
 	statedb.AddAddressToAccessList(addr)
 

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -609,6 +609,9 @@ func (evm *EVM) resolveCode(addr common.Address) []byte {
 	if !evm.chainRules.IsPrague {
 		return code
 	}
+	if !types.IsDelegationDesignatorLength(len(code)) {
+		return code
+	}
 	if target, ok := types.ParseDelegation(code); ok {
 		// Note we only follow one level of delegation.
 		return evm.StateDB.GetCode(target)
@@ -622,10 +625,12 @@ func (evm *EVM) resolveCode(addr common.Address) []byte {
 // internally to associate jumpdest analysis to code.
 func (evm *EVM) resolveCodeHash(addr common.Address) common.Hash {
 	if evm.chainRules.IsPrague {
-		code := evm.StateDB.GetCode(addr)
-		if target, ok := types.ParseDelegation(code); ok {
-			// Note we only follow one level of delegation.
-			return evm.StateDB.GetCodeHash(target)
+		if types.IsDelegationDesignatorLength(evm.StateDB.GetCodeSize(addr)) {
+			code := evm.StateDB.GetCode(addr)
+			if target, ok := types.ParseDelegation(code); ok {
+				// Note we only follow one level of delegation.
+				return evm.StateDB.GetCodeHash(target)
+			}
 		}
 	}
 	return evm.StateDB.GetCodeHash(addr)

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -609,9 +609,6 @@ func (evm *EVM) resolveCode(addr common.Address) []byte {
 	if !evm.chainRules.IsPrague {
 		return code
 	}
-	if !types.IsDelegationDesignatorLength(len(code)) {
-		return code
-	}
 	if target, ok := types.ParseDelegation(code); ok {
 		// Note we only follow one level of delegation.
 		return evm.StateDB.GetCode(target)

--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -43,6 +43,11 @@ type StateDB interface {
 
 	// SetCode sets the new code for the address, and returns the previous code, if any.
 	SetCode(common.Address, []byte) []byte
+	// GetCodeSize returns the length of the account's code. Implementations must
+	// ensure GetCodeSize(addr) == len(GetCode(addr)). After Prague, CALL-family
+	// gas and resolveCodeHash use the size to decide whether code can be an
+	// EIP-7702 delegation designator before loading it; a mismatched size can
+	// skip delegation-target access-list charging.
 	GetCodeSize(common.Address) int
 
 	AddRefund(uint64)

--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -43,11 +43,14 @@ type StateDB interface {
 
 	// SetCode sets the new code for the address, and returns the previous code, if any.
 	SetCode(common.Address, []byte) []byte
-	// GetCodeSize returns the length of the account's code. Implementations must
-	// ensure GetCodeSize(addr) == len(GetCode(addr)). After Prague, CALL-family
-	// gas and resolveCodeHash use the size to decide whether code can be an
-	// EIP-7702 delegation designator before loading it; a mismatched size can
-	// skip delegation-target access-list charging.
+	// GetCodeSize returns the length of the account's code. This is a
+	// consensus-critical invariant: implementations MUST guarantee
+	// GetCodeSize(addr) == len(GetCode(addr)). After Prague, CALL-family gas and
+	// resolveCodeHash use the size to decide whether code can be an EIP-7702
+	// delegation designator before loading it. A mismatched size can skip
+	// delegation-target access-list charging and can desynchronize
+	// resolveCodeHash from resolveCode, associating jumpdest analysis with the
+	// wrong code hash.
 	GetCodeSize(common.Address) int
 
 	AddRefund(uint64)

--- a/core/vm/operations_acl.go
+++ b/core/vm/operations_acl.go
@@ -280,18 +280,20 @@ func makeCallVariantGasCallEIP7702(oldCalculator gasFunc) gasFunc {
 		}
 
 		// Check if code is a delegation and if so, charge for resolution.
-		if target, ok := types.ParseDelegation(evm.StateDB.GetCode(addr)); ok {
-			var cost uint64
-			if evm.StateDB.AddressInAccessList(target) {
-				cost = params.WarmStorageReadCostEIP2929
-			} else {
-				evm.StateDB.AddAddressToAccessList(target)
-				cost = params.ColdAccountAccessCostEIP2929
+		if types.IsDelegationDesignatorLength(evm.StateDB.GetCodeSize(addr)) {
+			if target, ok := types.ParseDelegation(evm.StateDB.GetCode(addr)); ok {
+				var cost uint64
+				if evm.StateDB.AddressInAccessList(target) {
+					cost = params.WarmStorageReadCostEIP2929
+				} else {
+					evm.StateDB.AddAddressToAccessList(target)
+					cost = params.ColdAccountAccessCostEIP2929
+				}
+				if !contract.UseGas(cost, evm.Config.Tracer, tracing.GasChangeCallStorageColdAccess) {
+					return 0, ErrOutOfGas
+				}
+				total += cost
 			}
-			if !contract.UseGas(cost, evm.Config.Tracer, tracing.GasChangeCallStorageColdAccess) {
-				return 0, ErrOutOfGas
-			}
-			total += cost
 		}
 
 		// Now call the old calculator, which takes into account


### PR DESCRIPTION
## Summary
- Gate EIP-7702 CALL-family gas and `resolveCodeHash` on designator-sized code via `IsDelegationDesignatorLength` / `GetCodeSize` before calling `GetCode` + `ParseDelegation`.
- Non-designator accounts no longer load full runtime code solely for the delegation check; valid designators keep the existing charge/resolve path.
- `resolveCode` left unchanged (still needs a full load to execute); size gate applies where it avoids a load.
- Add unit tests for max-size non-delegates, valid designators, and designator-length wrong-prefix code.
- Document on `StateDB.GetCodeSize` that implementations must keep `GetCodeSize(addr) == len(GetCode(addr))` (consensus-critical; includes jumpdest hash desync risk).

## Consensus note (`GetCodeSize` vs `GetCode`)
This change is safe iff `GetCodeSize(addr) == len(GetCode(addr))` for every `StateDB`. That holds for in-tree geth state. For Sei (separate size key written/deleted with code), it is verified below **without** bumping the go-ethereum pin.

In-tree geth already caches code on `stateObject`, so the largest practical win is for StateDBs (like Sei) where each `GetCode` is a full store read. The gas-path size gate still avoids a probe load before `resolveCode` runs.

**Tradeoff on the designator-hit path:** a delegated CALL now does `GetCodeSize` + `GetCode` where it previously did a single `GetCode`. For Sei-style StateDBs that is one extra small metadata read per delegated CALL, in exchange for skipping full-code loads on ordinary contracts (the common case).

## Test plan
- [x] `go test ./core/vm/ -run 'TestResolveCodeHash|TestCallVariantGasEIP7702'`
- [x] `go test ./...` (full suite on initial commit)
- [x] Sei keeper invariant (`GetCodeSize == len(GetCode)`) on current pin `v1.15.7-sei-18` — `go test ./x/evm/keeper/ -run TestGetCodeSizeMatchesGetCodeLength`
- [x] Sei StateDB bridge invariant — `go test ./x/evm/state/ -run TestStateDBGetCodeSizeMatchesGetCodeLength`
- [x] Evidence: https://github.com/sei-protocol/go-ethereum/pull/86#issuecomment-5152503396
- [x] Review feedback: drop redundant `resolveCode` guard; add 23-byte wrong-prefix tests; license/gofmt/stub `Copy`
- [x] Document load-bearing `GetCodeSize`/`GetCode` invariant on `core/vm/interface.go`
- [x] Strengthen invariant docs (jumpdest desync); exact gas surcharge vs baseline; explicit wrong-prefix fixtures