### PR TITLE
core/types: fix decodeSignature panic on invalid signature length

### DIFF
--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -271,7 +271,10 @@ func (s *modernSigner) SignatureValues(tx *Transaction, sig []byte) (R, S, V *bi
 	if tx.inner.chainID().Sign() != 0 && tx.inner.chainID().Cmp(s.chainID) != 0 {
 		return nil, nil, nil, fmt.Errorf("%w: have %d want %d", ErrInvalidChainId, tx.inner.chainID(), s.chainID)
 	}
-	R, S, _ = decodeSignature(sig)
+	R, S, _, err = decodeSignature(sig)
+	if err != nil {
+		return nil, nil, nil, err
+	}
 	V = big.NewInt(int64(sig[64]))
 	return R, S, V, nil
 }
@@ -362,7 +365,10 @@ func (s EIP155Signer) SignatureValues(tx *Transaction, sig []byte) (R, S, V *big
 	if tx.Type() != LegacyTxType {
 		return nil, nil, nil, ErrTxTypeNotSupported
 	}
-	R, S, V = decodeSignature(sig)
+	R, S, V, err = decodeSignature(sig)
+	if err != nil {
+		return nil, nil, nil, err
+	}
 	if s.chainId.Sign() != 0 {
 		V = big.NewInt(int64(sig[64] + 35))
 		V.Add(V, s.chainIdMul)
@@ -431,8 +437,8 @@ func (fs FrontierSigner) SignatureValues(tx *Transaction, sig []byte) (r, s, v *
 	if tx.Type() != LegacyTxType {
 		return nil, nil, nil, ErrTxTypeNotSupported
 	}
-	r, s, v = decodeSignature(sig)
-	return r, s, v, nil
+	r, s, v, err = decodeSignature(sig)
+	return r, s, v, err
 }
 
 // Hash returns the hash to be signed by the sender.
@@ -448,14 +454,14 @@ func (fs FrontierSigner) Hash(tx *Transaction) common.Hash {
 	})
 }
 
-func decodeSignature(sig []byte) (r, s, v *big.Int) {
+func decodeSignature(sig []byte) (r, s, v *big.Int, err error) {
 	if len(sig) != crypto.SignatureLength {
-		panic(fmt.Sprintf("wrong size for signature: got %d, want %d", len(sig), crypto.SignatureLength))
+		return nil, nil, nil, fmt.Errorf("wrong size for signature: got %d, want %d", len(sig), crypto.SignatureLength)
 	}
 	r = new(big.Int).SetBytes(sig[:32])
 	s = new(big.Int).SetBytes(sig[32:64])
 	v = new(big.Int).SetBytes([]byte{sig[64] + 27})
-	return r, s, v
+	return r, s, v, nil
 }
 
 func recoverPlain(sighash common.Hash, R, S, Vb *big.Int, homestead bool) (common.Address, error) {

--- a/core/types/transaction_signing_test.go
+++ b/core/types/transaction_signing_test.go
@@ -188,3 +188,22 @@ func createTestLegacyTxInner() *LegacyTx {
 		Data:     nil,
 	}
 }
+
+func TestSignatureValuesError(t *testing.T) {
+	tx := NewTransaction(0, common.Address{}, big.NewInt(0), 0, big.NewInt(0), nil)
+	signer := HomesteadSigner{}
+
+	invalidSig := make([]byte, 64)
+
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("Panicked for invalid signature length, expected error: %v", r)
+			}
+		}()
+		_, err := tx.WithSignature(signer, invalidSig)
+		if err == nil {
+			t.Fatal("Expected error for invalid signature length, got nil")
+		}
+	}()
+}

--- a/core/types/tx_setcode.go
+++ b/core/types/tx_setcode.go
@@ -101,7 +101,10 @@ func SignSetCode(prv *ecdsa.PrivateKey, auth SetCodeAuthorization) (SetCodeAutho
 	if err != nil {
 		return SetCodeAuthorization{}, err
 	}
-	r, s, _ := decodeSignature(sig)
+	r, s, _, err := decodeSignature(sig)
+	if err != nil {
+		return SetCodeAuthorization{}, err
+	}
 	return SetCodeAuthorization{
 		ChainID: auth.ChainID,
 		Address: auth.Address,


### PR DESCRIPTION
## Summary

Ports upstream geth fix [ethereum/go-ethereum#33647](https://github.com/ethereum/go-ethereum/pull/33647) (`8fad02ac`).

`decodeSignature` panicked when `len(sig) != crypto.SignatureLength` (65 bytes) instead of returning an error. That turned malformed caller-controlled signature bytes into a process crash rather than a recoverable validation failure.

Reachable via `Transaction.WithSignature` → `Signer.SignatureValues` → `decodeSignature`, and via `SignSetCode` in `tx_setcode.go`.

## Changes

### A. `core/types/transaction_signing.go` — return error from `decodeSignature`

- Change `decodeSignature` to return `(r, s, v, error)` with a descriptive length error
- Propagate the error through `modernSigner`, `EIP155Signer`, and `FrontierSigner` `SignatureValues`

### B. `core/types/tx_setcode.go` — handle error in `SignSetCode`

- Propagate `decodeSignature` error instead of ignoring it

### C. `core/types/transaction_signing_test.go` — regression test

- Add `TestSignatureValuesError`: 64-byte sig to `WithSignature` must return error, not panic

## Why it matters for Sei

The vulnerable code is compiled into `seid` and used by Sei's EVM stack. While standard Sei RPC paths (`eth_sendRawTransaction`, `eth_sign`) do not pass user-controlled compact signatures into `WithSignature`, the library API surface is still reachable from signing/bind/wallet code paths. Returning errors keeps invalid input on the validation path instead of crashing the process.

Tracked in [PLT-906](https://linear.app/seilabs/issue/PLT-906/port-upstream-fix-decodesignature-panics-on-bad-signature-length).

## Test plan

- [x] `go test ./core/types/ -run TestSignatureValuesError`
- [x] `go test ./core/types/`
- [ ] `go build ./...`