### PR TITLE
core/txpool: fix list.Add() totalcost overflow (both mutation paths)

### DIFF
--- a/core/txpool/legacypool/list.go
+++ b/core/txpool/legacypool/list.go
@@ -331,6 +331,14 @@ func (l *list) Add(tx *types.Transaction, priceBump uint64) (bool, *types.Transa
 	if overflow {
 		return false, nil
 	}
+	if _, overflow = new(uint256.Int).AddOverflow(l.totalcost, cost); overflow {
+		if old != nil {
+			// Old cost was already subtracted above; restore it since the
+			// replacement is being rejected and old remains in the list.
+			l.totalcost.Add(l.totalcost, uint256.MustFromBig(old.Cost()))
+		}
+		return false, nil
+	}
 	l.totalcost.Add(l.totalcost, cost)
 
 	// Otherwise overwrite the old transaction with the current one

--- a/core/txpool/legacypool/list.go
+++ b/core/txpool/legacypool/list.go
@@ -323,23 +323,22 @@ func (l *list) Add(tx *types.Transaction, priceBump uint64) (bool, *types.Transa
 		if tx.GasFeeCapIntCmp(thresholdFeeCap) < 0 || tx.GasTipCapIntCmp(thresholdTip) < 0 {
 			return false, nil
 		}
-		// Old is being replaced, subtract old cost
-		l.subTotalCost([]*types.Transaction{old})
 	}
-	// Add new tx cost to totalcost
+	// Compute the list's total cost with the new tx applied (and the old one,
+	// if any, replaced) on a scratch value first, so a rejection never leaves
+	// l.totalcost partially mutated.
 	cost, overflow := uint256.FromBig(tx.Cost())
 	if overflow {
 		return false, nil
 	}
-	if _, overflow = new(uint256.Int).AddOverflow(l.totalcost, cost); overflow {
-		if old != nil {
-			// Old cost was already subtracted above; restore it since the
-			// replacement is being rejected and old remains in the list.
-			l.totalcost.Add(l.totalcost, uint256.MustFromBig(old.Cost()))
-		}
+	projected := new(uint256.Int).Set(l.totalcost)
+	if old != nil {
+		projected.SubOverflow(projected, uint256.MustFromBig(old.Cost()))
+	}
+	if _, overflow = projected.AddOverflow(projected, cost); overflow {
 		return false, nil
 	}
-	l.totalcost.Add(l.totalcost, cost)
+	l.totalcost.Set(projected)
 
 	// Otherwise overwrite the old transaction with the current one
 	l.txs.Put(tx)

--- a/core/txpool/legacypool/list_test.go
+++ b/core/txpool/legacypool/list_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/holiman/uint256"
@@ -77,24 +78,63 @@ func TestListAddTotalcostOverflow(t *testing.T) {
 
 	// First tx: cost equal to the max uint256 value (gasLimit 0 keeps gas cost
 	// out of the equation, so cost == value).
-	maxUint256 := uint256.NewInt(0).Not(uint256.NewInt(0)).ToBig()
-	tx0, _ := types.SignTx(types.NewTransaction(0, common.Address{}, maxUint256, 0, big.NewInt(1), nil), types.HomesteadSigner{}, key)
+	tx0, _ := types.SignTx(types.NewTx(&types.LegacyTx{Nonce: 0, To: &common.Address{}, Value: math.MaxBig256, Gas: 0, GasPrice: big.NewInt(1)}), types.HomesteadSigner{}, key)
 	if added, _ := list.Add(tx0, DefaultConfig.PriceBump); !added {
 		t.Fatalf("expected first transaction to be added")
 	}
-	if list.totalcost.Cmp(uint256.MustFromBig(maxUint256)) != 0 {
-		t.Fatalf("totalcost mismatch after first add: have %v, want %v", list.totalcost, maxUint256)
+	if list.totalcost.Cmp(uint256.MustFromBig(math.MaxBig256)) != 0 {
+		t.Fatalf("totalcost mismatch after first add: have %v, want %v", list.totalcost, math.MaxBig256)
 	}
 
 	// Second tx: any positive cost added on top now overflows totalcost.
-	tx1, _ := types.SignTx(types.NewTransaction(1, common.Address{}, big.NewInt(1), 0, big.NewInt(1), nil), types.HomesteadSigner{}, key)
+	tx1, _ := types.SignTx(types.NewTx(&types.LegacyTx{Nonce: 1, To: &common.Address{}, Value: big.NewInt(1), Gas: 0, GasPrice: big.NewInt(1)}), types.HomesteadSigner{}, key)
 	added, _ := list.Add(tx1, DefaultConfig.PriceBump)
 	if added {
 		t.Fatalf("expected overflowing transaction to be rejected")
 	}
 	// totalcost must be untouched by the rejected add.
-	if list.totalcost.Cmp(uint256.MustFromBig(maxUint256)) != 0 {
-		t.Fatalf("totalcost corrupted by rejected add: have %v, want %v", list.totalcost, maxUint256)
+	if list.totalcost.Cmp(uint256.MustFromBig(math.MaxBig256)) != 0 {
+		t.Fatalf("totalcost corrupted by rejected add: have %v, want %v", list.totalcost, math.MaxBig256)
+	}
+	// The rejected tx must not have been stored either.
+	if list.txs.Get(1) != nil {
+		t.Fatalf("rejected transaction should not be stored in the list")
+	}
+}
+
+// TestListAddTotalCostOverflowOnReplace tests the fee-bump replacement path:
+// if applying a valid replacement (subtracting the old tx's cost and adding
+// the new one) would overflow totalcost, the replacement must be rejected
+// and totalcost/the stored tx must be left exactly as they were.
+func TestListAddTotalCostOverflowOnReplace(t *testing.T) {
+	key, _ := crypto.GenerateKey()
+	list := newList(true)
+
+	// Filler tx at a different nonce, pushing totalcost close to the ceiling.
+	filler, _ := types.SignTx(types.NewTx(&types.LegacyTx{Nonce: 2, To: &common.Address{}, Value: new(big.Int).Sub(math.MaxBig256, big.NewInt(10)), Gas: 0, GasPrice: big.NewInt(1)}), types.HomesteadSigner{}, key)
+	if added, _ := list.Add(filler, DefaultConfig.PriceBump); !added {
+		t.Fatalf("expected filler transaction to be added")
+	}
+
+	// Original tx at nonce 0, low gas price so a fee-bumped replacement is easy to construct.
+	orig, _ := types.SignTx(types.NewTx(&types.LegacyTx{Nonce: 0, To: &common.Address{}, Value: big.NewInt(5), Gas: 0, GasPrice: big.NewInt(10)}), types.HomesteadSigner{}, key)
+	if added, _ := list.Add(orig, DefaultConfig.PriceBump); !added {
+		t.Fatalf("expected original transaction to be added")
+	}
+	totalBefore := new(uint256.Int).Set(list.totalcost)
+
+	// Replacement satisfies the fee-bump requirement (higher gas price) but its
+	// cost, once substituted for orig's, would overflow totalcost.
+	replacement, _ := types.SignTx(types.NewTx(&types.LegacyTx{Nonce: 0, To: &common.Address{}, Value: big.NewInt(11), Gas: 0, GasPrice: big.NewInt(100)}), types.HomesteadSigner{}, key)
+	added, _ := list.Add(replacement, DefaultConfig.PriceBump)
+	if added {
+		t.Fatalf("expected overflowing replacement to be rejected")
+	}
+	if list.totalcost.Cmp(totalBefore) != 0 {
+		t.Fatalf("totalCost corrupted by rejected replacement: have %v, want %v", list.totalcost, totalBefore)
+	}
+	if list.txs.Get(0) != orig {
+		t.Fatalf("rejected replacement should leave the original transaction in place")
 	}
 }
 

--- a/core/txpool/legacypool/list_test.go
+++ b/core/txpool/legacypool/list_test.go
@@ -68,6 +68,36 @@ func TestListAddVeryExpensive(t *testing.T) {
 	}
 }
 
+// TestListAddTotalcostOverflow tests that adding a transaction whose cost, once
+// accumulated onto the list's totalcost, would overflow 256 bits is rejected
+// rather than silently wrapping the tracked total.
+func TestListAddTotalcostOverflow(t *testing.T) {
+	key, _ := crypto.GenerateKey()
+	list := newList(true)
+
+	// First tx: cost equal to the max uint256 value (gasLimit 0 keeps gas cost
+	// out of the equation, so cost == value).
+	maxUint256 := uint256.NewInt(0).Not(uint256.NewInt(0)).ToBig()
+	tx0, _ := types.SignTx(types.NewTransaction(0, common.Address{}, maxUint256, 0, big.NewInt(1), nil), types.HomesteadSigner{}, key)
+	if added, _ := list.Add(tx0, DefaultConfig.PriceBump); !added {
+		t.Fatalf("expected first transaction to be added")
+	}
+	if list.totalcost.Cmp(uint256.MustFromBig(maxUint256)) != 0 {
+		t.Fatalf("totalcost mismatch after first add: have %v, want %v", list.totalcost, maxUint256)
+	}
+
+	// Second tx: any positive cost added on top now overflows totalcost.
+	tx1, _ := types.SignTx(types.NewTransaction(1, common.Address{}, big.NewInt(1), 0, big.NewInt(1), nil), types.HomesteadSigner{}, key)
+	added, _ := list.Add(tx1, DefaultConfig.PriceBump)
+	if added {
+		t.Fatalf("expected overflowing transaction to be rejected")
+	}
+	// totalcost must be untouched by the rejected add.
+	if list.totalcost.Cmp(uint256.MustFromBig(maxUint256)) != 0 {
+		t.Fatalf("totalcost corrupted by rejected add: have %v, want %v", list.totalcost, maxUint256)
+	}
+}
+
 func BenchmarkListAdd(b *testing.B) {
 	// Generate a list of transactions to insert
 	key, _ := crypto.GenerateKey()


### PR DESCRIPTION
## Summary
- `list.Add()` accumulated a new transaction's cost into `l.totalcost` via a plain `uint256.Add`, with no overflow check — a crafted-cost transaction could wrap the account's tracked total around 2^256, corrupting per-account queue cost accounting used for balance/eviction decisions. Fixed upstream by geth's `d68528ca` (#32544). Note: unreachable via the live network path today, since `ValidateTransactionWithState` already rejects any tx whose cost exceeds the sender's balance — this is defense-in-depth against a bad accounting invariant, not a live exploit.
- `Add()` is restructured to validate the fully-applied cost (subtracting any replaced tx's cost, then adding the new tx's cost) on a scratch `uint256.Int` first, and only commits to `l.totalcost` once the whole operation is known to succeed. This closes both overflow-mutation paths in one shot:
  - the plain accumulation path (the originally reported bug), and
  - the fee-bump replacement path, where the old tx's cost had already been subtracted from `totalcost` before the new cost's overflow check ran, which could leave `totalcost` permanently under-reported (and later trigger a `subTotalCost` underflow panic) if the replacement's cost happened to overflow.
- Added `TestListAddTotalcostOverflow` (plain accumulation) and `TestListAddTotalCostOverflowOnReplace` (fee-bump replacement), each asserting the transaction is rejected, `totalcost` is left exactly as it was, and the rejected tx is not stored.

Fixes PLT-909.

## Test plan
- [x] `go test ./core/txpool/...` passes (`blobpool`, `legacypool`, `locals`)
- [x] `TestListAddTotalcostOverflow` covers the plain-accumulation overflow-rejection path
- [x] `TestListAddTotalCostOverflowOnReplace` covers the fee-bump replacement overflow-rejection path