### PR TITLE
triedb/pathdb: fix journal RLP nil/empty-slice conflation; fix flaky TestWSConcurrentLargeFrames

### DIFF
--- a/rpc/testservice_test.go
+++ b/rpc/testservice_test.go
@@ -219,6 +219,20 @@ func (s *notificationTestService) HangSubscription(ctx context.Context, val int)
 	return subscription, nil
 }
 
+// syncSleepService behaves like testService.Sleep but signals startedCh the
+// moment the method starts executing, i.e. after the server has admitted the
+// request (acquired any WS concurrency budget for it). Tests use this as a
+// deterministic alternative to polling the budget semaphore.
+type syncSleepService struct {
+	startedCh chan struct{}
+}
+
+// Sleep is invoked reflectively by the RPC server when it receives a request for synctest_sleep
+func (s *syncSleepService) Sleep(duration time.Duration) {
+	s.startedCh <- struct{}{}
+	time.Sleep(duration)
+}
+
 // largeRespService generates arbitrary-size JSON responses.
 type largeRespService struct {
 	length int

--- a/rpc/ws_admission_test.go
+++ b/rpc/ws_admission_test.go
@@ -66,6 +66,15 @@ func makeSleepMsg(id int, sleep time.Duration, pad int) string {
 	)
 }
 
+// makeSyncSleepMsg builds a request for syncSleepService, registered under the
+// "synctest" name.
+func makeSyncSleepMsg(id int, sleep time.Duration, pad int) string {
+	return fmt.Sprintf(
+		`{"jsonrpc":"2.0","id":%d,"method":"synctest_sleep","params":[%d],"_pad":"%s"}`,
+		id, sleep.Nanoseconds(), strings.Repeat("x", pad),
+	)
+}
+
 func TestWSIdleConnectionsDoNotHoldBudget(t *testing.T) {
 	t.Parallel()
 
@@ -420,8 +429,14 @@ func TestWSConcurrentLargeFrames(t *testing.T) {
 		pad           = 48
 	)
 
+	started := make(chan struct{}, 2)
+	svc := &syncSleepService{startedCh: started}
+
 	srv := newTestServer()
-	payload := makeSleepMsg(1, sleepDuration, pad)
+	if err := srv.RegisterName("synctest", svc); err != nil {
+		t.Fatalf("register synctest service: %v", err)
+	}
+	payload := makeSyncSleepMsg(1, sleepDuration, pad)
 	frameSize := int64(len(payload))
 	srv.SetReadLimits(frameSize)
 	srv.SetWSConcurrentRequestBytes(2 * frameSize)
@@ -430,35 +445,33 @@ func TestWSConcurrentLargeFrames(t *testing.T) {
 	conn := dialWS(t, wsURL)
 	t.Cleanup(func() { conn.Close() })
 
-	writeWSJSON(t, conn, makeSleepMsg(1, sleepDuration, pad))
-	writeWSJSON(t, conn, makeSleepMsg(2, sleepDuration, pad))
+	writeWSJSON(t, conn, makeSyncSleepMsg(1, sleepDuration, pad))
+	writeWSJSON(t, conn, makeSyncSleepMsg(2, sleepDuration, pad))
 
-	// With budget == frameSize the two requests would serialize; with 2*frameSize
-	// both should hold budget while test_sleep runs.
-	overlapDeadline := time.Now().Add(sleepDuration)
-	var overlapped bool
-	for time.Now().Before(overlapDeadline) {
-		if !srv.wsConcurrentBudget.TryAcquire(frameSize) {
-			overlapped = true
-			break
+	// Both requests must be admitted (budget acquired) and start sleeping well
+	// before either finishes. If the budget only allowed one at a time, the
+	// second "started" signal would not arrive until after the first request's
+	// full sleepDuration has elapsed and it released its share of the budget.
+	overlapWait := sleepDuration / 2
+	for i := 0; i < 2; i++ {
+		select {
+		case <-started:
+		case <-time.After(overlapWait):
+			t.Fatal("expected two large frames to hold byte budget concurrently")
 		}
-		srv.wsConcurrentBudget.Release(frameSize)
-		time.Sleep(5 * time.Millisecond)
-	}
-	if !overlapped {
-		t.Fatal("expected two large frames to hold byte budget concurrently")
 	}
 
-	var firstResp jsonrpcMessage
-	readWSJSON(t, conn, &firstResp)
-	if string(firstResp.ID) != "1" {
-		t.Fatalf("expected first response id 1, got %s", string(firstResp.ID))
+	// The two requests run concurrently in separate goroutines with identical
+	// sleep durations, so the server gives no guarantee about which response
+	// is written first.
+	gotIDs := make(map[string]bool, 2)
+	for i := 0; i < 2; i++ {
+		var resp jsonrpcMessage
+		readWSJSON(t, conn, &resp)
+		gotIDs[string(resp.ID)] = true
 	}
-
-	var secondResp jsonrpcMessage
-	readWSJSON(t, conn, &secondResp)
-	if string(secondResp.ID) != "2" {
-		t.Fatalf("expected second response id 2, got %s", string(secondResp.ID))
+	if !gotIDs["1"] || !gotIDs["2"] {
+		t.Fatalf("expected responses for ids 1 and 2, got %v", gotIDs)
 	}
 }
 

--- a/triedb/pathdb/iterator_test.go
+++ b/triedb/pathdb/iterator_test.go
@@ -798,7 +798,8 @@ func testAccountIteratorDeletions(t *testing.T, newIterator func(db *Database, r
 	config := &Config{
 		WriteBufferSize: 0,
 	}
-	db := New(rawdb.NewMemoryDatabase(), config, false)
+	memoryDB := rawdb.NewMemoryDatabase()
+	db := New(memoryDB, config, false)
 	// db.WaitGeneration()
 
 	// Stack three diff layers on top with various overlaps
@@ -814,32 +815,56 @@ func testAccountIteratorDeletions(t *testing.T, newIterator func(db *Database, r
 	db.Update(common.HexToHash("0x04"), common.HexToHash("0x03"), 3, trienode.NewMergedNodeSet(),
 		NewStateSetWithOrigin(randomAccountSet("0x33", "0x44", "0x55"), nil, nil, nil, false))
 
-	// The output should be 11,33,44,55
-	it := newIterator(db, common.HexToHash("0x04"), common.Hash{})
-	// Do a quick check
-	verifyIterator(t, 4, it, verifyAccount)
-	it.Release()
+	verify := func() {
+		// The output should be 11,33,44,55
+		it := newIterator(db, common.HexToHash("0x04"), common.Hash{})
+		// Do a quick check
+		verifyIterator(t, 4, it, verifyAccount)
+		it.Release()
 
-	// And a more detailed verification that we indeed do not see '0x22'
-	it = newIterator(db, common.HexToHash("0x04"), common.Hash{})
-	defer it.Release()
-	for it.Next() {
-		hash := it.Hash()
-		if it.Account() == nil {
-			t.Errorf("iterator returned nil-value for hash %x", hash)
-		}
-		if hash == deleted {
-			t.Errorf("expected deleted elem %x to not be returned by iterator", deleted)
+		// And a more detailed verification that we indeed do not see '0x22'
+		it = newIterator(db, common.HexToHash("0x04"), common.Hash{})
+		defer it.Release()
+		for it.Next() {
+			hash := it.Hash()
+			if it.Account() == nil {
+				t.Errorf("iterator returned nil-value for hash %x", hash)
+			}
+			if hash == deleted {
+				t.Errorf("expected deleted elem %x to not be returned by iterator", deleted)
+			}
 		}
 	}
+	verify()
+
+	if err := db.Journal(common.HexToHash("0x04")); err != nil {
+		t.Fatalf("Failed to journal the database, %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("Failed to close the database, %v", err)
+	}
+	db = New(memoryDB, config, false)
+
+	verify()
 }
 
 func TestStorageIteratorDeletions(t *testing.T) {
 	config := &Config{
 		WriteBufferSize: 0,
 	}
-	db := New(rawdb.NewMemoryDatabase(), config, false)
+	memoryDB := rawdb.NewMemoryDatabase()
+	db := New(memoryDB, config, false)
 	// db.WaitGeneration()
+
+	restart := func(head common.Hash) {
+		if err := db.Journal(head); err != nil {
+			t.Fatalf("Failed to journal the database, %v", err)
+		}
+		if err := db.Close(); err != nil {
+			t.Fatalf("Failed to close the database, %v", err)
+		}
+		db = New(memoryDB, config, false)
+	}
 
 	// Stack three diff layers on top with various overlaps
 	db.Update(common.HexToHash("0x02"), types.EmptyRootHash, 1, trienode.NewMergedNodeSet(),
@@ -850,6 +875,19 @@ func TestStorageIteratorDeletions(t *testing.T) {
 
 	// The output should be 02,04,05,06
 	it, _ := db.StorageIterator(common.HexToHash("0x03"), common.HexToHash("0xaa"), common.Hash{})
+	verifyIterator(t, 4, it, verifyStorage)
+	it.Release()
+
+	// The output should be 04,05,06
+	it, _ = db.StorageIterator(common.HexToHash("0x03"), common.HexToHash("0xaa"), common.HexToHash("0x03"))
+	verifyIterator(t, 3, it, verifyStorage)
+	it.Release()
+
+	// Ensure the iteration result aligns after the database restart
+	restart(common.HexToHash("0x03"))
+
+	// The output should be 02,04,05,06
+	it, _ = db.StorageIterator(common.HexToHash("0x03"), common.HexToHash("0xaa"), common.Hash{})
 	verifyIterator(t, 4, it, verifyStorage)
 	it.Release()
 
@@ -869,9 +907,23 @@ func TestStorageIteratorDeletions(t *testing.T) {
 	verifyIterator(t, 0, it, verifyStorage)
 	it.Release()
 
+	// Ensure the iteration result aligns after the database restart
+	restart(common.HexToHash("0x04"))
+	it, _ = db.StorageIterator(common.HexToHash("0x04"), common.HexToHash("0xaa"), common.Hash{})
+	verifyIterator(t, 0, it, verifyStorage)
+	it.Release()
+
 	// Re-insert the slots of the same account
 	db.Update(common.HexToHash("0x05"), common.HexToHash("0x04"), 4, trienode.NewMergedNodeSet(),
 		NewStateSetWithOrigin(randomAccountSet("0xaa"), randomStorageSet([]string{"0xaa"}, [][]string{{"0x07", "0x08", "0x09"}}, nil), nil, nil, false))
+
+	// The output should be 07,08,09
+	it, _ = db.StorageIterator(common.HexToHash("0x05"), common.HexToHash("0xaa"), common.Hash{})
+	verifyIterator(t, 3, it, verifyStorage)
+	it.Release()
+
+	// Ensure the iteration result aligns after the database restart
+	restart(common.HexToHash("0x05"))
 
 	// The output should be 07,08,09
 	it, _ = db.StorageIterator(common.HexToHash("0x05"), common.HexToHash("0xaa"), common.Hash{})
@@ -886,6 +938,13 @@ func TestStorageIteratorDeletions(t *testing.T) {
 	verifyIterator(t, 2, it, verifyStorage) // The output should be 11,12
 	it.Release()
 
+	verifyIterator(t, 2, db.tree.get(common.HexToHash("0x06")).(*diffLayer).newBinaryStorageIterator(common.HexToHash("0xaa"), common.Hash{}), verifyStorage)
+
+	// Ensure the iteration result aligns after the database restart
+	restart(common.HexToHash("0x06"))
+	it, _ = db.StorageIterator(common.HexToHash("0x06"), common.HexToHash("0xaa"), common.Hash{})
+	verifyIterator(t, 2, it, verifyStorage) // The output should be 11,12
+	it.Release()
 	verifyIterator(t, 2, db.tree.get(common.HexToHash("0x06")).(*diffLayer).newBinaryStorageIterator(common.HexToHash("0xaa"), common.Hash{}), verifyStorage)
 }
 

--- a/triedb/pathdb/states.go
+++ b/triedb/pathdb/states.go
@@ -385,8 +385,8 @@ func (s *stateSet) decode(r *rlp.Stream) error {
 	if err := r.Decode(&dec); err != nil {
 		return fmt.Errorf("load diff accounts: %v", err)
 	}
-	for i := 0; i < len(dec.AddrHashes); i++ {
-		accountSet[dec.AddrHashes[i]] = dec.Accounts[i]
+	for i := range dec.AddrHashes {
+		accountSet[dec.AddrHashes[i]] = empty2nil(dec.Accounts[i])
 	}
 	s.accountData = accountSet
 
@@ -405,8 +405,8 @@ func (s *stateSet) decode(r *rlp.Stream) error {
 	}
 	for _, entry := range storages {
 		storageSet[entry.AddrHash] = make(map[common.Hash][]byte, len(entry.Keys))
-		for i := 0; i < len(entry.Keys); i++ {
-			storageSet[entry.AddrHash][entry.Keys[i]] = entry.Vals[i]
+		for i := range entry.Keys {
+			storageSet[entry.AddrHash][entry.Keys[i]] = empty2nil(entry.Vals[i])
 		}
 	}
 	s.storageData = storageSet
@@ -545,8 +545,8 @@ func (s *StateSetWithOrigin) decode(r *rlp.Stream) error {
 	if err := r.Decode(&accounts); err != nil {
 		return fmt.Errorf("load diff account origin set: %v", err)
 	}
-	for i := 0; i < len(accounts.Accounts); i++ {
-		accountSet[accounts.Addresses[i]] = accounts.Accounts[i]
+	for i := range accounts.Accounts {
+		accountSet[accounts.Addresses[i]] = empty2nil(accounts.Accounts[i])
 	}
 	s.accountOrigin = accountSet
 
@@ -565,10 +565,17 @@ func (s *StateSetWithOrigin) decode(r *rlp.Stream) error {
 	}
 	for _, storage := range storages {
 		storageSet[storage.Address] = make(map[common.Hash][]byte)
-		for i := 0; i < len(storage.Keys); i++ {
-			storageSet[storage.Address][storage.Keys[i]] = storage.Vals[i]
+		for i := range storage.Keys {
+			storageSet[storage.Address][storage.Keys[i]] = empty2nil(storage.Vals[i])
 		}
 	}
 	s.storageOrigin = storageSet
 	return nil
+}
+
+func empty2nil(b []byte) []byte {
+	if len(b) == 0 {
+		return nil
+	}
+	return b
 }

--- a/triedb/pathdb/states_test.go
+++ b/triedb/pathdb/states_test.go
@@ -325,6 +325,36 @@ func testStatesEncode(t *testing.T, rawStorageKey bool) {
 	}
 }
 
+func TestStatesEncodeDeletionMarkers(t *testing.T) {
+	s := newStates(
+		map[common.Hash][]byte{
+			{0xa}: {0xa0},
+			{0xb}: nil, // deleted account
+		},
+		map[common.Hash]map[common.Hash][]byte{
+			{0xa}: {
+				common.Hash{0x1}: {0x10},
+				common.Hash{0x2}: nil, // deleted slot
+			},
+		},
+		false,
+	)
+	buf := bytes.NewBuffer(nil)
+	if err := s.encode(buf); err != nil {
+		t.Fatalf("Failed to encode states, %v", err)
+	}
+	var dec stateSet
+	if err := dec.decode(rlp.NewStream(buf, 0)); err != nil {
+		t.Fatalf("Failed to decode states, %v", err)
+	}
+	if dec.accountData[common.Hash{0xb}] != nil {
+		t.Fatalf("Deleted account decoded as non-nil empty slice: %v", dec.accountData[common.Hash{0xb}])
+	}
+	if dec.storageData[common.Hash{0xa}][common.Hash{0x2}] != nil {
+		t.Fatalf("Deleted storage slot decoded as non-nil empty slice: %v", dec.storageData[common.Hash{0xa}][common.Hash{0x2}])
+	}
+}
+
 func TestStateWithOriginEncode(t *testing.T) {
 	testStateWithOriginEncode(t, false)
 	testStateWithOriginEncode(t, true)


### PR DESCRIPTION
## Summary

Two independent fixes:

1. Ports upstream geth fix [ethereum/go-ethereum#32097](https://github.com/ethereum/go-ethereum/pull/32097) (`36bcc24f`) for PathDB journal RLP nil/empty-slice conflation.
2. Fixes a flaky RPC websocket admission-control test, `TestWSConcurrentLargeFrames`.

## 1. PathDB journal RLP nil/empty-slice conflation

PathDB journals in-memory diff layers with RLP. RLP does not preserve the distinction between `nil` and `[]byte{}`, so journal reload can turn deletion markers into invalid empty account/storage values. After restart, the PBSS state iterator can then return those entries instead of treating them as deleted, which upstream surfaces as SNAP sync failures (`err="range contains deletion"`).

### Changes

**`triedb/pathdb/states.go`** — normalize decoded journal values

Add `empty2nil()` and apply it in all four journal decode paths:
- `stateSet.decode` (accounts + storage)
- `StateSetWithOrigin.decode` (account origin + storage origin)

**`triedb/pathdb/states_test.go`** — deletion-marker round-trip test

Add `TestStatesEncodeDeletionMarkers` to assert `nil` deletions survive encode/decode as `nil`, not `[]byte{}`.

**`triedb/pathdb/iterator_test.go`** — journal restart regression coverage

Extend account/storage deletion iterator tests to journal → close → reopen and re-verify iteration results.

### Why it matters for Sei

Sei nodes use SeiDB for primary state, but the go-ethereum fork still carries PathDB (e.g. eth replay read-only when path scheme is in use). This is a small, self-contained correctness fix in the forked dependency.

Tracked in [PLT-951](https://linear.app/seilabs/issue/PLT-951/port-upstream-fix-pathdb-journal-rlp-nilempty-slice-conflation).

## 2. Flaky `TestWSConcurrentLargeFrames`

The test asserted that two large WS frames held the concurrency-budget semaphore simultaneously by busy-polling `TryAcquire`/`Release` against a wall-clock deadline computed after the frames were written. Under CI/scheduler load this window could close before the poll observed the overlap, and the same busy-polling contended on the very semaphore under test. Separately, the test also asserted a strict response order (id 1 before id 2) even though both requests run concurrently in independent goroutines with identical sleep durations, so completion order is not actually guaranteed.

### Changes

**`rpc/testservice_test.go`** — add `syncSleepService`, a test-only RPC service whose `Sleep` method signals a channel the instant it starts executing (i.e. right after the server has admitted/acquired budget for the request), before it sleeps.

**`rpc/ws_admission_test.go`**
- Add `makeSyncSleepMsg` to build requests against the new `synctest_sleep` method.
- `TestWSConcurrentLargeFrames` now registers `syncSleepService` and waits on its `started` channel for exactly 2 signals (bounded well under `sleepDuration`) instead of busy-polling the budget semaphore.
- Read both responses and check the set of ids rather than asserting a fixed order.

## Test plan

- [x] `go test ./triedb/pathdb/... -run 'TestStatesEncodeDeletionMarkers|TestAccountIteratorDeletions|TestStorageIteratorDeletions' -count=1`
- [x] `go test ./rpc/... -run TestWSConcurrentLargeFrames -count=50`
- [x] `go test ./rpc/... -run TestWSConcurrentLargeFrames -race -count=20`
- [x] `go test ./triedb/pathdb/...`
- [x] `go test ./rpc/...`