### PR TITLE
core/vm: don't call SetCode after contract creation if initcode returned nothing

### DIFF
--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -583,7 +583,9 @@ func (evm *EVM) initNewContract(contract *Contract, address common.Address) ([]b
 		}
 	}
 
-	evm.StateDB.SetCode(address, ret)
+	if len(ret) > 0 {
+		evm.StateDB.SetCode(address, ret)
+	}
 	return ret, nil
 }
 


### PR DESCRIPTION
## Summary

`initNewContract` unconditionally called `evm.StateDB.SetCode(address, ret)` after running a contract's creation code, even when `ret` (the returned init code) was empty. This is a manual port of upstream go-ethereum fix [b6a4ac99](https://github.com/ethereum/go-ethereum/commit/b6a4ac996) (go-ethereum#32916).

## Why this matters for Sei

Sei's `DBImpl.SetCode` (`x/evm/state/code.go`) always performs a `PrefixStore.Set()` on the code, code-size, and code-hash keys — even when writing empty code. Sei's OCC (optimistic concurrency control) multi-version executor tracks exactly these writes to build each transaction's write-set.

That means every no-op `CREATE`/`CREATE2` (initcode that returns no bytecode) registered a real write against the new contract address's code keys, even though nothing actually changed. Under OCC, this produces a **spurious write conflict** against any other concurrent transaction reading or writing code at that same address — causing unnecessary re-execution/aborts that have nothing to do with an actual state change.

`vm.NewEVM` is Sei's live CREATE/CREATE2 path, reachable from `x/evm/keeper/evm.go`, `msg_server.go`, `abci.go`, `ante/fee.go`, and `pointer_upgrade.go`, so this is a real, currently-reachable source of avoidable OCC conflicts in block execution, not just a latent upstream nit.

## Fix

Only call `SetCode` when `len(ret) > 0`, matching upstream's guard.

Linear: [PLT-960](https://linear.app/seilabs/issue/PLT-960/corevm-initnewcontract-calls-setcode-unconditionally-on-empty-initcode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)