### PR TITLE
fix(tracers): honor trace_timeout in traceBlock loops (PLT-986)

### DIFF
--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -644,7 +644,7 @@ func (api *API) traceBlock(ctx context.Context, block *types.Block, metadata []t
 	if len(metadata) == 0 {
 		for i, tx := range txs {
 			if err := ctx.Err(); err != nil {
-				return nil, fmt.Errorf("trace aborted at tx %d/%d: %w", i, len(txs), err)
+				return nil, fmt.Errorf("trace aborted at tx %d/%d: %w", i+1, len(txs), err)
 			}
 			// Generate the next state snapshot fast without tracing
 			msg, _ := core.TransactionToMessage(tx, signer, block.BaseFee())

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -661,7 +661,7 @@ func (api *API) traceBlock(ctx context.Context, block *types.Block, metadata []t
 		return results, nil
 	}
 	for _, md := range metadata {
-		if err := ctx.Err(); err != nil {
+		if err = ctx.Err(); err != nil {
 			return nil, err
 		}
 		if md.ShouldIncludeInTraceResult {

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -661,6 +661,9 @@ func (api *API) traceBlock(ctx context.Context, block *types.Block, metadata []t
 		return results, nil
 	}
 	for _, md := range metadata {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		if md.ShouldIncludeInTraceResult {
 			i := md.IdxInEthBlock
 			tx := txs[i]

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -643,8 +643,8 @@ func (api *API) traceBlock(ctx context.Context, block *types.Block, metadata []t
 	)
 	if len(metadata) == 0 {
 		for i, tx := range txs {
-			if err = ctx.Err(); err != nil {
-				return nil, err
+			if err := ctx.Err(); err != nil {
+				return nil, fmt.Errorf("trace aborted at tx %d/%d: %w", i, len(txs), err)
 			}
 			// Generate the next state snapshot fast without tracing
 			msg, _ := core.TransactionToMessage(tx, signer, block.BaseFee())

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -663,9 +663,9 @@ func (api *API) traceBlock(ctx context.Context, block *types.Block, metadata []t
 		}
 		return results, nil
 	}
-	for _, md := range metadata {
-		if err = ctx.Err(); err != nil {
-			return nil, err
+	for i, md := range metadata {
+		if err := ctx.Err(); err != nil {
+			return nil, fmt.Errorf("trace aborted at metadata entry %d/%d: %w", i+1, len(metadata), err)
 		}
 		if md.ShouldIncludeInTraceResult {
 			i := md.IdxInEthBlock

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -643,6 +643,9 @@ func (api *API) traceBlock(ctx context.Context, block *types.Block, metadata []t
 	)
 	if len(metadata) == 0 {
 		for i, tx := range txs {
+			if err = ctx.Err(); err != nil {
+				return nil, err
+			}
 			// Generate the next state snapshot fast without tracing
 			msg, _ := core.TransactionToMessage(tx, signer, block.BaseFee())
 			txctx := &Context{

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -696,23 +696,32 @@ func TestTraceBlockMetadataLoopRespectsContext(t *testing.T) {
 	}
 
 	var runnableCalls atomic.Int32
-	metadata := []tracersutils.TraceBlockMetadata{{
-		ShouldIncludeInTraceResult: false,
-		TraceRunnable: func(vm.StateDB) {
-			runnableCalls.Add(1)
-			t.Error("TraceRunnable should not run after context is done")
-		},
-	}}
-
-	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	_, err := api.traceBlock(ctx, block, metadata, nil)
-	if !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled) {
-		t.Fatalf("expected context error, got %v", err)
+	metadata := []tracersutils.TraceBlockMetadata{
+		{
+			ShouldIncludeInTraceResult: false,
+			TraceRunnable: func(vm.StateDB) {
+				runnableCalls.Add(1)
+				cancel()
+			},
+		},
+		{
+			ShouldIncludeInTraceResult: false,
+			TraceRunnable: func(vm.StateDB) {
+				runnableCalls.Add(1)
+				t.Error("TraceRunnable should not run after context is canceled between iterations")
+			},
+		},
 	}
-	if runnableCalls.Load() != 0 {
-		t.Fatalf("expected TraceRunnable not to run, calls=%d", runnableCalls.Load())
+
+	_, err := api.traceBlock(ctx, block, metadata, nil)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+	if runnableCalls.Load() != 1 {
+		t.Fatalf("expected exactly one TraceRunnable call, got %d", runnableCalls.Load())
 	}
 }
 

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -746,6 +746,8 @@ func registerCancelAfterFirstTxTracer(cancel context.CancelFunc, traced *atomic.
 	return name
 }
 
+// TestTraceBlockEVMLoopRespectsContext must not call t.Parallel: it registers a
+// per-run tracer into DefaultDirectory, whose elems map is not safe for concurrent writes.
 func TestTraceBlockEVMLoopRespectsContext(t *testing.T) {
 	accounts := newAccounts(2)
 	genesis := &core.Genesis{

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -51,9 +51,9 @@ import (
 )
 
 var (
-	errStateNotFound        = errors.New("state not found")
-	errBlockNotFound        = errors.New("block not found")
-	evmLoopCancelTracerID   atomic.Int64
+	errStateNotFound      = errors.New("state not found")
+	errBlockNotFound      = errors.New("block not found")
+	evmLoopCancelTracerID atomic.Int64
 )
 
 type testBackend struct {

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -51,8 +51,9 @@ import (
 )
 
 var (
-	errStateNotFound = errors.New("state not found")
-	errBlockNotFound = errors.New("block not found")
+	errStateNotFound        = errors.New("state not found")
+	errBlockNotFound        = errors.New("block not found")
+	evmLoopCancelTracerID   atomic.Int64
 )
 
 type testBackend struct {
@@ -722,6 +723,75 @@ func TestTraceBlockMetadataLoopRespectsContext(t *testing.T) {
 	}
 	if runnableCalls.Load() != 1 {
 		t.Fatalf("expected exactly one TraceRunnable call, got %d", runnableCalls.Load())
+	}
+}
+
+func registerCancelAfterFirstTxTracer(cancel context.CancelFunc, traced *atomic.Int32) string {
+	name := fmt.Sprintf("cancelAfterFirstTxEndTracer%d", evmLoopCancelTracerID.Add(1))
+	DefaultDirectory.Register(name, func(_ *Context, _ json.RawMessage, _ *params.ChainConfig) (*Tracer, error) {
+		return &Tracer{
+			Hooks: &tracing.Hooks{
+				OnTxEnd: func(_ *types.Receipt, _ error) {
+					if traced.Add(1) == 1 {
+						cancel()
+					}
+				},
+			},
+			GetResult: func() (json.RawMessage, error) {
+				return json.RawMessage(`{}`), nil
+			},
+			Stop: func(error) {},
+		}, nil
+	}, false)
+	return name
+}
+
+func TestTraceBlockEVMLoopRespectsContext(t *testing.T) {
+	accounts := newAccounts(2)
+	genesis := &core.Genesis{
+		Config: params.TestChainConfig,
+		Alloc: types.GenesisAlloc{
+			accounts[0].addr: {Balance: big.NewInt(params.Ether)},
+			accounts[1].addr: {Balance: big.NewInt(params.Ether)},
+		},
+	}
+	signer := types.HomesteadSigner{}
+	backend := newTestBackend(t, 1, genesis, func(i int, b *core.BlockGen) {
+		for nonce := uint64(0); nonce < 2; nonce++ {
+			tx, _ := types.SignTx(types.NewTx(&types.LegacyTx{
+				Nonce:    nonce,
+				To:       &accounts[1].addr,
+				Value:    big.NewInt(1),
+				Gas:      params.TxGas,
+				GasPrice: b.BaseFee(),
+			}), signer, accounts[0].key)
+			b.AddTx(tx)
+		}
+	})
+	defer backend.teardown()
+	api := NewAPI(backend)
+
+	block := backend.chain.GetBlockByNumber(1)
+	if block == nil {
+		t.Fatal("expected block 1")
+	}
+	if block.Transactions().Len() != 2 {
+		t.Fatalf("expected block with 2 transactions, got %d", block.Transactions().Len())
+	}
+
+	var tracedTxs atomic.Int32
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	tracerName := registerCancelAfterFirstTxTracer(cancel, &tracedTxs)
+	config := &TraceConfig{Tracer: &tracerName}
+
+	_, err := api.traceBlock(ctx, block, nil, config)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+	if tracedTxs.Load() != 1 {
+		t.Fatalf("expected exactly one traced transaction, got %d", tracedTxs.Load())
 	}
 }
 

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -24,8 +24,8 @@ import (
 	"fmt"
 	"math/big"
 	"reflect"
-	"strings"
 	"slices"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -662,6 +662,57 @@ func TestTraceBlock(t *testing.T) {
 		if string(have) != want {
 			t.Errorf("test %d, result mismatch, have\n%v\n, want\n%v\n", i, string(have), want)
 		}
+	}
+}
+
+func TestTraceBlockMetadataLoopRespectsContext(t *testing.T) {
+	t.Parallel()
+
+	accounts := newAccounts(2)
+	genesis := &core.Genesis{
+		Config: params.TestChainConfig,
+		Alloc: types.GenesisAlloc{
+			accounts[0].addr: {Balance: big.NewInt(params.Ether)},
+			accounts[1].addr: {Balance: big.NewInt(params.Ether)},
+		},
+	}
+	signer := types.HomesteadSigner{}
+	backend := newTestBackend(t, 1, genesis, func(i int, b *core.BlockGen) {
+		tx, _ := types.SignTx(types.NewTx(&types.LegacyTx{
+			Nonce:    uint64(i),
+			To:       &accounts[1].addr,
+			Value:    big.NewInt(1),
+			Gas:      params.TxGas,
+			GasPrice: b.BaseFee(),
+		}), signer, accounts[0].key)
+		b.AddTx(tx)
+	})
+	defer backend.teardown()
+	api := NewAPI(backend)
+
+	block := backend.chain.GetBlockByNumber(1)
+	if block == nil {
+		t.Fatal("expected block 1")
+	}
+
+	var runnableCalls atomic.Int32
+	metadata := []tracersutils.TraceBlockMetadata{{
+		ShouldIncludeInTraceResult: false,
+		TraceRunnable: func(vm.StateDB) {
+			runnableCalls.Add(1)
+			t.Error("TraceRunnable should not run after context is done")
+		},
+	}}
+
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer cancel()
+
+	_, err := api.traceBlock(ctx, block, metadata, nil)
+	if !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context error, got %v", err)
+	}
+	if runnableCalls.Load() != 0 {
+		t.Fatalf("expected TraceRunnable not to run, calls=%d", runnableCalls.Load())
 	}
 }
 


### PR DESCRIPTION
## Summary

`debug_traceBlockByNumber` on CosmWasm-heavy blocks can fill all trace concurrency slots and leave the node permanently returning `"server busy"` until restart ([sei-chain #3900](https://github.com/sei-protocol/sei-chain/issues/3900)).

`sei-chain` passes a timeout context via `prepareTraceContext` (`trace_timeout`, default 30s). On the default block-trace path, Cosmos/Wasm txs are replayed through `TraceRunnable` → `DeliverTx` inside `traceBlock`, but the metadata loop never checked `ctx.Err()` between iterations — so handlers kept running (and holding slots) after timeout.

The same per-iteration check is also added to the EVM-only loop (`len(metadata) == 0`) so client cancel / timeout stops further `traceTx` calls between pure-EVM txs (consistency with the metadata path; not the primary PLT-986 trigger).

Fixes PLT-986.

## Changes

- **`eth/tracers/api.go`**: return early from `traceBlock` when `ctx.Err()` is set:
  - **Metadata loop** — before each `traceTx` / `TraceRunnable` iteration (CosmWasm/Cosmos replay path)
  - **EVM-only loop** — before each `traceTx` when `len(metadata) == 0` (returns wrapped `trace aborted at tx i/n: …` for easier debugging)
- **`eth/tracers/api_test.go`**: context-cancellation regression tests for both loops:
  - `TestTraceBlockMetadataLoopRespectsContext` — cancel between metadata iterations (first `TraceRunnable` calls `cancel()`, second never runs)
  - `TestTraceBlockEVMLoopRespectsContext` — cancel after first tx on EVM-only path via test tracer `OnTxEnd`

Same pattern already used in `sei-chain/evmrpc/simulate.go` (`ReplayTransactionTillIndex`).

## What this fixes

- Timed-out or canceled block traces exit instead of replaying the rest of the block
- Upstream `sei-chain` handlers can release trace semaphore slots via existing `defer done()` without requiring a process restart

## RPC behavior note

When `traceBlock` hits a canceled or timed-out context mid-block, it returns `(nil, err)` and **does not return partial trace results** collected before the stop. Callers of `debug_traceBlockByNumber` / `debug_traceBlockByHash` will see a bare RPC error rather than a truncated result array. This matches the existing `ReplayTransactionTillIndex` behavior in sei-chain and is intentional: a timed-out trace is treated as failed, not partially successful.

On the EVM-only path, the error is wrapped with the tx index (`trace aborted at tx i/n`); the metadata path returns the context error directly.

## Out of scope

- Does not cancel a `DeliverTx` already blocked inside Wasm execution — only stops starting further replays after timeout
- Does not cover go-ethereum `traceBlockParallel` (JS tracers only; separate from default struct-logger path)
- **sei-chain follow-ups (after merge):**
  - **Required:** bump `go.mod` replace pin to pick up this fix for the default `debug_traceBlock*` path
  - **Separate:** [PLT-989](https://linear.app/seilabs/issue/PLT-989) — same `ctx.Err()` checks in `evmrpc/block_trace_profiled.go` when `evm.enable_parallelized_block_trace = true` (opt-in path; not fixed by the dependency bump alone)

## Test plan

- [x] `go test ./eth/tracers/ -run TestTraceBlockMetadataLoopRespectsContext -count=1`
- [x] `go test ./eth/tracers/ -run TestTraceBlockEVMLoopRespectsContext -count=1`