### PR TITLE
internal/ethapi: reject gasPrice together with authorizationList

### DIFF
--- a/internal/ethapi/transaction_args.go
+++ b/internal/ethapi/transaction_args.go
@@ -195,6 +195,12 @@ func (args *TransactionArgs) setFeeDefaults(ctx context.Context, b Backend, head
 	if args.GasPrice != nil && (args.MaxFeePerGas != nil || args.MaxPriorityFeePerGas != nil) {
 		return errors.New("both gasPrice and (maxFeePerGas or maxPriorityFeePerGas) specified")
 	}
+	// An EIP-7702 set-code transaction cannot be a legacy transaction, so gasPrice
+	// is incompatible with an authorization list. Reject the combination instead of
+	// silently dropping the authorization list in ToTransaction.
+	if args.GasPrice != nil && args.AuthorizationList != nil {
+		return errors.New("both gasPrice and authorizationList specified")
+	}
 	// If the tx has completely specified a fee mechanism, no default is needed.
 	// This allows users who are not yet synced past London to get defaults for
 	// other tx values. See https://github.com/ethereum/go-ethereum/pull/23274

--- a/internal/ethapi/transaction_args_test.go
+++ b/internal/ethapi/transaction_args_test.go
@@ -58,6 +58,7 @@ func TestSetFeeDefaults(t *testing.T) {
 		fortytwo = (*hexutil.Big)(big.NewInt(42))
 		maxFee   = (*hexutil.Big)(new(big.Int).Add(new(big.Int).Mul(b.current.BaseFee, big.NewInt(2)), fortytwo.ToInt()))
 		al       = &types.AccessList{types.AccessTuple{Address: common.Address{0xaa}, StorageKeys: []common.Hash{{0x01}}}}
+		authList = []types.SetCodeAuthorization{{Address: common.Address{0xbb}}}
 	)
 
 	tests := []test{
@@ -207,6 +208,13 @@ func TestSetFeeDefaults(t *testing.T) {
 			&TransactionArgs{GasPrice: fortytwo, MaxFeePerGas: maxFee},
 			nil,
 			errors.New("both gasPrice and (maxFeePerGas or maxPriorityFeePerGas) specified"),
+		},
+		{
+			"set gas price and authorization list",
+			"london",
+			&TransactionArgs{GasPrice: fortytwo, AuthorizationList: authList},
+			nil,
+			errors.New("both gasPrice and authorizationList specified"),
 		},
 		// EIP-4844
 		{


### PR DESCRIPTION
## Summary

Ports upstream [ethereum/go-ethereum#35320](https://github.com/ethereum/go-ethereum/pull/35320).

When RPC callers send both `gasPrice` and `authorizationList`, `TransactionArgs.ToTransaction` first selects the EIP-7702 set-code tx type, then downgrades to legacy whenever `gasPrice` is set. Legacy transactions cannot carry an authorization list, so the list was silently dropped and `eth_sendTransaction`, `eth_signTransaction`, and `eth_fillTransaction` could return a plain legacy transaction/hash even though the requested delegation update was never included.

This change rejects the incompatible combination in `setFeeDefaults`, mirroring the existing `gasPrice` + EIP-1559 guard, so the request fails explicitly instead of producing a transaction that omits the authorization list.

## Changes

- Add validation in `setFeeDefaults` to return `both gasPrice and authorizationList specified`
- Add a `TestSetFeeDefaults` case covering the new error path

## Test plan

- [x] `go test ./internal/ethapi/ -run TestSetFeeDefaults`
