### PR TITLE
internal/ethapi: include AuthorizationList in gas estimation callArgs

### DIFF
--- a/internal/ethapi/transaction_args.go
+++ b/internal/ethapi/transaction_args.go
@@ -158,6 +158,7 @@ func (args *TransactionArgs) SetDefaults(ctx context.Context, b Backend, skipGas
 				AccessList:           args.AccessList,
 				BlobFeeCap:           args.BlobFeeCap,
 				BlobHashes:           args.BlobHashes,
+				AuthorizationList:    args.AuthorizationList,
 			}
 			latestBlockNr := rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber)
 			estimated, err := DoEstimateGas(ctx, b, callArgs, latestBlockNr, nil, nil, b.RPCGasCap())


### PR DESCRIPTION
## Summary

Ports [ethereum/go-ethereum#33849](https://github.com/ethereum/go-ethereum/pull/33849).

When `SetDefaults` auto-estimates gas for a transaction without an explicit `gas` field, it builds a `callArgs` copy and passes it to `DoEstimateGas`. That copy included fields like `AccessList` and `BlobHashes`, but omitted `AuthorizationList`.

For EIP-7702 SetCode transactions, the authorization list applies code delegations that can change the execution path and gas usage. Estimating without it produces incorrect gas limits, which can lead to out-of-gas failures when the transaction is actually submitted.

This adds `AuthorizationList` to the estimation `callArgs` so the dry-run matches the real transaction.

## Test plan

- [x] `go test ./internal/ethapi/`